### PR TITLE
Add opt-in dark mode with a nav toggle (light mode unchanged)

### DIFF
--- a/cypress/e2e/e2e.cy.js
+++ b/cypress/e2e/e2e.cy.js
@@ -90,4 +90,19 @@ describe('Load the website page', function () {
         // Verify filters were applied and cards are still displayed
         cy.get('.card').should('have.length.greaterThan', 0);
     });
+
+    it('toggles dark mode, persists it across pages and switches back', () => {
+        cy.visit(appUrl);
+        cy.get('html').should('not.have.attr', 'data-theme');
+
+        cy.get('.theme-toggle').click();
+        cy.get('html').should('have.attr', 'data-theme', 'dark');
+
+        // the choice must survive navigation to a different page
+        cy.visit(appUrl + '/about/');
+        cy.get('html').should('have.attr', 'data-theme', 'dark');
+
+        cy.get('.theme-toggle').click();
+        cy.get('html').should('not.have.attr', 'data-theme');
+    });
 });

--- a/website/404/index.html
+++ b/website/404/index.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem("theme")==="dark"){document.documentElement.setAttribute("data-theme","dark")}}catch(e){}
+    </script>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/website/about/index.html
+++ b/website/about/index.html
@@ -1,5 +1,9 @@
 ﻿<!DOCTYPE html>
 <html lang="en"><head>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem("theme")==="dark"){document.documentElement.setAttribute("data-theme","dark")}}catch(e){}
+    </script>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/website/blog/8-training-routines-to-boost-climbing-performance/index.html
+++ b/website/blog/8-training-routines-to-boost-climbing-performance/index.html
@@ -4,6 +4,10 @@
     <script>
         window.performance.mark('start');
     </script>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
+    </script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/blog/a-very-un-british-way-to-build-climbing-anchors/index.html
+++ b/website/blog/a-very-un-british-way-to-build-climbing-anchors/index.html
@@ -4,6 +4,10 @@
     <script>
         window.performance.mark('start');
     </script>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
+    </script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -4,6 +4,10 @@
     <script>
         window.performance.mark('start');
     </script>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
+    </script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/blog/trad-climbing-gear-teir-list-2025/index.html
+++ b/website/blog/trad-climbing-gear-teir-list-2025/index.html
@@ -4,6 +4,10 @@
     <script>
         window.performance.mark('start');
     </script>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
+    </script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/climbing-tips/climbing-gear/index.html
+++ b/website/climbing-tips/climbing-gear/index.html
@@ -4,6 +4,10 @@
     <script>
         window.performance.mark('start');
     </script>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
+    </script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/climbing-tips/climbing-grades/index.html
+++ b/website/climbing-tips/climbing-grades/index.html
@@ -4,6 +4,10 @@
     <script>
         window.performance.mark('start');
     </script>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
+    </script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/climbing-tips/climbing-terminology/index.html
+++ b/website/climbing-tips/climbing-terminology/index.html
@@ -4,6 +4,10 @@
     <script>
         window.performance.mark('start');
     </script>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
+    </script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/climbing-tips/index.html
+++ b/website/climbing-tips/index.html
@@ -4,6 +4,10 @@
     <script>
         window.performance.mark('start');
     </script>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
+    </script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/climbing-tips/rock-types/index.html
+++ b/website/climbing-tips/rock-types/index.html
@@ -4,6 +4,10 @@
     <script>
         window.performance.mark('start');
     </script>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
+    </script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/components/head.html
+++ b/website/components/head.html
@@ -4,6 +4,10 @@
     <script>
         window.performance.mark('start');
     </script>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
+    </script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -1970,13 +1970,6 @@ hr {
     margin-top: 0;
   }
 }
-/* DARK MODE
-@media (prefers-color-scheme: dark) {
-  body{
-    background: #333;
-    color: #FFF;
-  }
-} */
 .map-card-body {
     -webkit-box-flex: 1;
     -ms-flex: 1 1 auto;
@@ -2249,4 +2242,206 @@ input[type="range"]::-ms-range-thumb {
   video[autoplay].danger-gif {
     display: none;
   }
+}
+
+/***************/
+/** DARK MODE **/
+/* Everything below only applies when the user opts in via the nav toggle
+   (html gets data-theme="dark", persisted in localStorage). With the
+   attribute absent none of these rules match, so the default look is
+   untouched. */
+.theme-toggle {
+  background: none;
+  border: 1px solid rgba(255, 255, 255, .45);
+  color: #FFF;
+  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  padding: 4px;
+  cursor: pointer;
+  vertical-align: middle;
+  margin-left: .4rem;
+}
+.theme-toggle:hover {
+  border-color: #FFF;
+}
+.theme-toggle svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+.theme-toggle .tt-sun {
+  display: none;
+}
+html[data-theme="dark"] .theme-toggle .tt-sun {
+  display: block;
+}
+html[data-theme="dark"] .theme-toggle .tt-moon {
+  display: none;
+}
+html[data-theme="dark"] {
+  color-scheme: dark;
+  --dm-bg: #121821;
+  --dm-surface: #1c2331;
+  --dm-surface-2: #242e40;
+  --dm-text: #dfe3e8;
+  --dm-text-muted: #b3bcc7;
+  --dm-link: #7db3ff;
+  --dm-link-hover: #a9ccff;
+  --dm-border: #4a5568;
+}
+html[data-theme="dark"] body {
+  background-color: var(--dm-bg);
+  color: var(--dm-text);
+}
+html[data-theme="dark"] a {
+  color: var(--dm-link);
+}
+html[data-theme="dark"] a:hover {
+  color: var(--dm-link-hover);
+}
+html[data-theme="dark"] hr {
+  border-bottom-color: rgba(255, 255, 255, .15);
+}
+/* links that sit on dark surfaces in both themes stay white */
+html[data-theme="dark"] nav ul li a,
+html[data-theme="dark"] footer.page-footer a,
+html[data-theme="dark"] .pop-up-title a,
+html[data-theme="dark"] .blog-caption a {
+  color: #FFF;
+}
+html[data-theme="dark"] nav ul li a:hover {
+  color: rgba(255, 255, 255, .75);
+}
+html[data-theme="dark"] .card {
+  background-color: var(--dm-surface);
+  border-color: rgba(255, 255, 255, .16);
+}
+html[data-theme="dark"] .card .card-body .card-text,
+html[data-theme="dark"] .card .map-card-body .card-text,
+html[data-theme="dark"] .nearby-climb .card-text {
+  color: var(--dm-text-muted);
+}
+html[data-theme="dark"] .nearby-climb .card-text strong {
+  color: var(--dm-text);
+}
+html[data-theme="dark"] .card a picture {
+  background-color: #39424e;
+  color: #c6ccd4;
+  animation: none;
+}
+html[data-theme="dark"] .open-tile,
+html[data-theme="dark"] .primary-link {
+  color: var(--dm-link);
+  border-color: var(--dm-border);
+  background: transparent;
+}
+html[data-theme="dark"] .open-tile:focus,
+html[data-theme="dark"] [role="button"][aria-pressed="true"],
+html[data-theme="dark"] .primary-link:focus {
+  border-color: #7d92b5;
+  background: #31435f;
+}
+html[data-theme="dark"] .filters {
+  background-color: rgba(255, 255, 255, .07);
+}
+html[data-theme="dark"] .filter-toggle {
+  color: var(--dm-link);
+}
+html[data-theme="dark"] select {
+  border-bottom-color: rgba(255, 255, 255, .25);
+}
+html[data-theme="dark"] select:-moz-focusring {
+  text-shadow: 0 0 0 #fff;
+}
+html[data-theme="dark"] .subscribe,
+html[data-theme="dark"] .big-card-body,
+html[data-theme="dark"] .map-card-body,
+html[data-theme="dark"] .topo-controls {
+  background-color: var(--dm-surface);
+}
+/* the subscribe and grade-conversion fragments carry inline
+   color/background styles, hence the !important */
+html[data-theme="dark"] .big-card {
+  color: var(--dm-text) !important;
+  background: var(--dm-surface) !important;
+}
+html[data-theme="dark"] .map-card-body:after,
+html[data-theme="dark"] .map-card-body:before {
+  border-bottom-color: var(--dm-surface);
+}
+html[data-theme="dark"] .leaflet-popup-content-wrapper,
+html[data-theme="dark"] .leaflet-popup-tip {
+  background: var(--dm-surface);
+  color: var(--dm-text);
+}
+html[data-theme="dark"] .gradeLabel {
+  background-color: var(--dm-surface-2);
+  border-color: var(--dm-border);
+}
+html[data-theme="dark"] .gradeLabel:hover {
+  background-color: #31435f;
+}
+html[data-theme="dark"] td {
+  border-color: var(--dm-border);
+}
+html[data-theme="dark"] #gradeTable .active {
+  /* the conversion table highlights cells with pastel backgrounds;
+     keep dark text on them */
+  color: #111;
+}
+html[data-theme="dark"] .info-ring,
+html[data-theme="dark"] .info-divider {
+  border-color: #8b95a5;
+}
+html[data-theme="dark"] .compass {
+  /* the compass artwork needs a light disc to stay legible */
+  background-color: #dfe3e8;
+  border-radius: 50%;
+}
+html[data-theme="dark"] .compass .single-attribute {
+  color: #111;
+}
+html[data-theme="dark"] .social-share a {
+  color: #c6ccd4;
+}
+html[data-theme="dark"] .credit a,
+html[data-theme="dark"] blockquote:before,
+html[data-theme="dark"] #lastDate {
+  color: #9aa3ad;
+}
+html[data-theme="dark"] footer .grey {
+  background: #161d29;
+  color: var(--dm-text);
+}
+html[data-theme="dark"] footer .grey a {
+  color: var(--dm-link);
+}
+html[data-theme="dark"] .loading p {
+  color: var(--dm-text-muted);
+}
+html[data-theme="dark"] .loading img {
+  /* the loading logo is white; the light theme inverts it to black */
+  filter: none;
+}
+html[data-theme="dark"] .chart {
+  background-image: linear-gradient(to top, rgba(255, 255, 255, .12) 2%, rgba(255, 255, 255, 0) 2%);
+}
+html[data-theme="dark"] .weatherChev {
+  color: var(--dm-text);
+}
+html[data-theme="dark"] .inactiveChev {
+  color: #5c6672;
+}
+html[data-theme="dark"] summary:focus {
+  background: rgba(122, 130, 183, .3);
+}
+html[data-theme="dark"] input:disabled + span {
+  color: #5c6672;
+}
+html[data-theme="dark"] .slider {
+  background: #dddddd40;
+}
+html[data-theme="dark"] .cat-img {
+  background-color: #39424e;
 }

--- a/website/index.html
+++ b/website/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
 <head>
     <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem("theme")==="dark"){document.documentElement.setAttribute("data-theme","dark")}}catch(e){}
+    </script>
+    <script>
         window.performance.mark('start');
     </script>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -45,6 +45,52 @@ if (!"content" in document.createElement("template") && document.getElementById(
     // browser does not support <template> element
     document.getElementById('ie-warn').setAttribute('style', 'display:block;');
 }
+
+/**
+ * DARK MODE TOGGLE
+ * The saved theme is applied before first paint by an inline snippet in each
+ * page's <head>; this only builds the nav button and handles switching.
+ **/
+(function initThemeToggle() {
+    if (document.readyState === 'loading') {
+        // the homepage loads this module async, so the nav may not be parsed yet
+        document.addEventListener('DOMContentLoaded', initThemeToggle);
+        return;
+    }
+    const navList = document.querySelector('nav ul');
+    if (!navList || document.querySelector('.theme-toggle')) { return; }
+
+    const isDark = () => document.documentElement.getAttribute('data-theme') === 'dark';
+    const li = document.createElement('li');
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'theme-toggle';
+    button.innerHTML =
+        '<svg class="tt-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>' +
+        '<svg class="tt-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><path d="M12 1v3M12 20v3M4.22 4.22l2.12 2.12M17.66 17.66l2.12 2.12M1 12h3M20 12h3M4.22 19.78l2.12-2.12M17.66 6.34l2.12-2.12"/></svg>';
+
+    const reflectTheme = function () {
+        button.setAttribute('aria-pressed', isDark());
+        button.setAttribute('aria-label', isDark() ? 'Switch to light theme' : 'Switch to dark theme');
+        const themeColorMeta = document.querySelector('meta[name="theme-color"]');
+        if (themeColorMeta) {
+            themeColorMeta.setAttribute('content', isDark() ? '#121821' : '#ffffff');
+        }
+    };
+    button.addEventListener('click', function () {
+        const next = isDark() ? 'light' : 'dark';
+        if (next === 'dark') {
+            document.documentElement.setAttribute('data-theme', 'dark');
+        } else {
+            document.documentElement.removeAttribute('data-theme');
+        }
+        try { localStorage.setItem('theme', next); } catch (e) { /* storage unavailable */ }
+        reflectTheme();
+    });
+    reflectTheme();
+    li.appendChild(button);
+    navList.appendChild(li);
+})();
 var webPsupport = (function() {
     var webP = new Image();
     webP.onload = WebP.onerror = function () {

--- a/website/map/index.html
+++ b/website/map/index.html
@@ -1,6 +1,10 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem("theme")==="dark"){document.documentElement.setAttribute("data-theme","dark")}}catch(e){}
+    </script>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />

--- a/website/topo-editor/index.html
+++ b/website/topo-editor/index.html
@@ -1,6 +1,10 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
+    <script>
+        /* apply the saved theme before first paint to avoid a light flash */
+        try{if(localStorage.getItem("theme")==="dark"){document.documentElement.setAttribute("data-theme","dark")}}catch(e){}
+    </script>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <!-- Styles -->


### PR DESCRIPTION
## What this adds

An **opt-in dark mode** with a moon/sun toggle in the nav. The default is exactly the current light look — nothing changes until a visitor presses the toggle, and pressing it again switches straight back. The choice is remembered (`localStorage`) across pages and visits.

## How it works

- **All dark styling is additive**: every rule is scoped under `html[data-theme="dark"]`, an attribute that only exists after the user opts in. With it absent, none of the dark rules match — light mode ships byte-identical CSS paths, so "switch back to how it is now" is guaranteed by construction. (Replaces the commented-out `DARK MODE` stub that was already sitting in style.css.)
- **The toggle** is injected into the nav by `main.js` on every page (the same progressive-enhancement pattern as the accessibility PR #70, so no per-page markup edits). Accessible: real `<button>`, `aria-pressed`, a label that announces what it will do, and it also keeps `<meta name="theme-color">` in sync so the mobile browser chrome matches.
- **No light flash for returning dark users**: a tiny inline script in every `<head>` applies the saved theme before first paint. It's in the `head.html` template (all generated pages pick it up) and the static pages (home, about, map, 404, topo-editor).
- The palette is navy-based, built off the existing `#1C2331` brand colour, with link/text colours chosen for WCAG AA contrast on the dark surfaces. `color-scheme: dark` makes native form controls (selects, checkboxes, inputs) render dark too.
- Special cases handled: the subscribe + grade-conversion modal fragments (they carry inline styles), the pastel grade-conversion table cells (keep dark text), leaflet map popups, the weather charts/chevrons, the compass widget, and the card-image loading shimmer. Map tiles deliberately stay light — dark chrome around a standard map.

## Screenshots

### Phone (390×844)

| Page | Light (unchanged) | Dark |
|---|---|---|
| Homepage | ![home light phone](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/home-iphone-light.png) | ![home dark phone](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/home-iphone-dark.png) |
| Climb page | ![climb light phone](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/climb-iphone-light.png) | ![climb dark phone](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/climb-iphone-dark.png) |
| Grade table | ![tips light phone](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/tips-iphone-light.png) | ![tips dark phone](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/tips-iphone-dark.png) |
| Blog post | ![blog light phone](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/blog-iphone-light.png) | ![blog dark phone](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/blog-iphone-dark.png) |

### Desktop (1440×900)

| Page | Light (unchanged) | Dark |
|---|---|---|
| Homepage hero | ![home light](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/home-desktop-light.png) | ![home dark](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/home-desktop-dark.png) |
| Climb cards + filters | ![cards light](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/home-cards-desktop-light.png) | ![cards dark](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/home-cards-desktop-dark.png) |
| Footer + disclaimer | ![footer light](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/home-footer-desktop-light.png) | ![footer dark](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/home-footer-desktop-dark.png) |
| Climb page | ![climb light](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/climb-desktop-light.png) | ![climb dark](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/climb-desktop-dark.png) |
| Grade conversion table | ![tips light](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/tips-desktop-light.png) | ![tips dark](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/tips-desktop-dark.png) |
| Map | ![map light](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/map-desktop-light.png) | ![map dark](https://raw.githubusercontent.com/dankni/multi-pitch/assets/dark-mode-screenshots/map-desktop-dark.png) |

Images live on the asset-only branch `assets/dark-mode-screenshots` (never merge it; delete it after this PR closes if you like).

## Verification

- **Light-mode regression**: before/after screenshots of 6 page types (home, climb, map, blog, tips, about) at iPhone + desktop widths — identical dimensions, visually identical except the new nav button.
- **New Cypress test**: toggle on → theme persists when navigating to another page → toggle off restores the default. **All 11 e2e tests pass.**
- `node --check` clean on main.js; the toggle waits for DOM readiness (the homepage loads main.js `async`).

## Not covered (small, deliberate)

- The `/training/` mini-apps have their own standalone styling and no nav — they stay light for now.
- Auto-following the OS `prefers-color-scheme` was left out on purpose so the default stays exactly the current look; easy follow-up if wanted.

## Merge order

Stacked on #72 (`fix/search-console-coverage`) — merge after it; GitHub retargets automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
