### PR TITLE
Dark mode review follow-up: central theme-init.js + system-preference default

### DIFF
--- a/cypress/e2e/e2e.cy.js
+++ b/cypress/e2e/e2e.cy.js
@@ -92,7 +92,9 @@ describe('Load the website page', function () {
     });
 
     it('toggles dark mode, persists it across pages and switches back', () => {
-        cy.visit(appUrl);
+        // the default follows the OS preference, so pin the starting point
+        // to make the test deterministic on any machine
+        cy.visit(appUrl, { onBeforeLoad(win) { win.localStorage.setItem('theme', 'light'); } });
         cy.get('html').should('not.have.attr', 'data-theme');
 
         cy.get('.theme-toggle').click();

--- a/website/404/index.html
+++ b/website/404/index.html
@@ -1,10 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem("theme")==="dark"){document.documentElement.setAttribute("data-theme","dark")}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/website/about/index.html
+++ b/website/about/index.html
@@ -1,9 +1,6 @@
 ﻿<!DOCTYPE html>
 <html lang="en"><head>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem("theme")==="dark"){document.documentElement.setAttribute("data-theme","dark")}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/website/blog/8-training-routines-to-boost-climbing-performance/index.html
+++ b/website/blog/8-training-routines-to-boost-climbing-performance/index.html
@@ -4,10 +4,7 @@
     <script>
         window.performance.mark('start');
     </script>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/blog/a-very-un-british-way-to-build-climbing-anchors/index.html
+++ b/website/blog/a-very-un-british-way-to-build-climbing-anchors/index.html
@@ -4,10 +4,7 @@
     <script>
         window.performance.mark('start');
     </script>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -4,10 +4,7 @@
     <script>
         window.performance.mark('start');
     </script>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/blog/trad-climbing-gear-teir-list-2025/index.html
+++ b/website/blog/trad-climbing-gear-teir-list-2025/index.html
@@ -4,10 +4,7 @@
     <script>
         window.performance.mark('start');
     </script>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/climbing-tips/climbing-gear/index.html
+++ b/website/climbing-tips/climbing-gear/index.html
@@ -4,10 +4,7 @@
     <script>
         window.performance.mark('start');
     </script>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/climbing-tips/climbing-grades/index.html
+++ b/website/climbing-tips/climbing-grades/index.html
@@ -4,10 +4,7 @@
     <script>
         window.performance.mark('start');
     </script>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/climbing-tips/climbing-terminology/index.html
+++ b/website/climbing-tips/climbing-terminology/index.html
@@ -4,10 +4,7 @@
     <script>
         window.performance.mark('start');
     </script>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/climbing-tips/index.html
+++ b/website/climbing-tips/index.html
@@ -4,10 +4,7 @@
     <script>
         window.performance.mark('start');
     </script>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/climbing-tips/rock-types/index.html
+++ b/website/climbing-tips/rock-types/index.html
@@ -4,10 +4,7 @@
     <script>
         window.performance.mark('start');
     </script>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/components/head.html
+++ b/website/components/head.html
@@ -4,10 +4,7 @@
     <script>
         window.performance.mark('start');
     </script>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem('theme')==='dark'){document.documentElement.setAttribute('data-theme','dark')}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />

--- a/website/index.html
+++ b/website/index.html
@@ -1,10 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem("theme")==="dark"){document.documentElement.setAttribute("data-theme","dark")}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
     <script>
         window.performance.mark('start');
     </script>

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -90,6 +90,28 @@ if (!"content" in document.createElement("template") && document.getElementById(
     reflectTheme();
     li.appendChild(button);
     navList.appendChild(li);
+
+    // Follow live OS theme changes while the visitor has not made an
+    // explicit choice (theme-init.js applies the same precedence on load).
+    if (window.matchMedia) {
+        const osPreference = window.matchMedia('(prefers-color-scheme: dark)');
+        const followOs = function (e) {
+            let stored = null;
+            try { stored = localStorage.getItem('theme'); } catch (err) { /* storage unavailable */ }
+            if (stored) { return; }
+            if (e.matches) {
+                document.documentElement.setAttribute('data-theme', 'dark');
+            } else {
+                document.documentElement.removeAttribute('data-theme');
+            }
+            reflectTheme();
+        };
+        if (typeof osPreference.addEventListener === 'function') {
+            osPreference.addEventListener('change', followOs);
+        } else if (typeof osPreference.addListener === 'function') {
+            osPreference.addListener(followOs); // older Safari
+        }
+    }
 })();
 var webPsupport = (function() {
     var webP = new Image();

--- a/website/js/theme-init.js
+++ b/website/js/theme-init.js
@@ -1,0 +1,17 @@
+// Applies the colour theme before first paint. Loaded synchronously (render-
+// blocking on purpose) from every page's <head> so dark-mode users never see
+// a light flash. Kept separate from main.js because main.js is a module and
+// therefore deferred past first paint.
+// Precedence: explicit user choice (localStorage) > OS preference > light.
+(function () {
+    try {
+        var stored = localStorage.getItem('theme');
+        var dark = stored === 'dark' ||
+            (!stored && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (dark) {
+            document.documentElement.setAttribute('data-theme', 'dark');
+        }
+    } catch (e) {
+        // storage unavailable -> fall through to the light default
+    }
+})();

--- a/website/map/index.html
+++ b/website/map/index.html
@@ -1,10 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem("theme")==="dark"){document.documentElement.setAttribute("data-theme","dark")}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />

--- a/website/topo-editor/index.html
+++ b/website/topo-editor/index.html
@@ -1,10 +1,7 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-    <script>
-        /* apply the saved theme before first paint to avoid a light flash */
-        try{if(localStorage.getItem("theme")==="dark"){document.documentElement.setAttribute("data-theme","dark")}}catch(e){}
-    </script>
+    <script src="/js/theme-init.js"></script>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <!-- Styles -->


### PR DESCRIPTION
Addresses @dankni's review on #75:

> The js in the head should be implemented somewhere central, either main.js (although that dosn't block render which you want of this to prevent the css flash) or as a separate central js file. Also the Css should use the system default media query with the option to change it i think.

## 1. Central file

The inline snippet is gone from every page head; it's now a single **`website/js/theme-init.js`**, loaded synchronously (deliberately render-blocking, ~200 bytes) from each `<head>` — exactly the "separate central js file" option, keeping the no-flash guarantee. As you noted, main.js can't host it: it's a module, so it's deferred past first paint.

## 2. System default, with the option to change

Dark now defaults to the OS preference. Precedence: **explicit user choice (localStorage) → `prefers-color-scheme` → light.**
- First-time visitor with OS dark mode → site is dark from first paint.
- The nav toggle overrides in either direction and is remembered.
- While no explicit choice is stored, the site follows live OS theme changes (media-query listener in main.js, with the legacy-Safari fallback).

One deviation from the letter of the suggestion: this is implemented in theme-init.js rather than a CSS `@media (prefers-color-scheme: dark)` block, because the dark styling is ~200 lines of `html[data-theme="dark"]` rules — duplicating them under a media query would mean maintaining two copies. Same behaviour (applies before first paint), one source of truth. Happy to restructure to CSS variables + media query in a follow-up if you'd prefer it strictly CSS-driven.

## Verification

- Headless-browser assertions, **7/7 pass**: OS-light default, OS-dark default (also on deep pages), explicit choice beating OS in both directions, toggle override + persistence under OS-dark.
- The Cypress dark-mode test now pins its starting theme (the old one assumed light-by-default, which broke on OS-dark machines — caught locally). **All 11 e2e tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)