### PR TITLE
Restore the deliberate /map/?loc crawl block

### DIFF
--- a/website/robots.txt
+++ b/website/robots.txt
@@ -1,13 +1,16 @@
 # /robots.txt file for https://www.multi-pitch.com
 
 User-agent: *
-Disallow:
+# /map/?loc= is deliberately blocked to preserve crawl budget —
+# every climb card links to a parameterised map URL and crawlers
+# were wasting budget looping through them. Trade-off: Search
+# Console will list these under "Blocked by robots.txt", which is
+# expected and can be ignored.
+Disallow: /map/?loc
 
 Sitemap: https://www.multi-pitch.com/sitemap.xml
 
-# /map/?loc= and /subscribe/ are intentionally crawlable:
-# the map page canonicalises to /map/ and the subscribe
-# fragment carries a noindex meta tag. Blocking them here
-# left Google unable to see either signal, producing
-# "Blocked by robots.txt" / "Indexed, though blocked by
-# robots.txt" coverage errors in Search Console.
+# /subscribe/ stays crawlable on purpose: the fragment carries a
+# noindex meta tag, and Google can only see it if allowed to crawl
+# (blocking it is what caused the "Indexed, though blocked by
+# robots.txt" Search Console error).


### PR DESCRIPTION
Follow-up to feedback on the Search Console changes: the `Disallow: /map/?loc` rule was **intentional** — the parameterised map URLs were wasting crawl budget with crawler loops — and #72 shouldn't have removed it.

This restores the rule and documents the reasoning in robots.txt itself, so the trade-off is explicit: those URLs will show up again under "Blocked by robots.txt" in Search Console, which is **expected and can be ignored**.

The `/subscribe/` part of #72 stands unchanged (crawlable + `noindex` — that one was a genuine fix for "Indexed, though blocked by robots.txt").

🤖 Generated with [Claude Code](https://claude.com/claude-code)