### PR TITLE
Restore climbing-grades as a standalone page; fix climbing-tips-removal fallout

### DIFF
--- a/generateContentPages.js
+++ b/generateContentPages.js
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import { updateBreadcrumb, generateIntroHTML, generateArticlesHTML } from './website/components/article.js';
+
+const page = '/climbing-grades/';
+
+const newScript = `<!--scripts -->
+<script src="/components/article.js" type="module"></script>
+<script>
+    window.addEventListener('DOMContentLoaded', (event) => {
+        makeLinksPushable();
+    });
+</script>`;
+
+const headHTML = fs.readFileSync('./website/components/head.html', 'utf8');
+const footerHTML = fs.readFileSync('./website/components/footer.html', 'utf8');
+const navHTML = fs.readFileSync('./website/components/nav.html', 'utf8');
+
+const content = JSON.parse(fs.readFileSync('./website' + page + 'content.json', 'utf8'));
+
+const breadcrumb = updateBreadcrumb(content.url);
+const introHTML = generateIntroHTML(content, breadcrumb);
+const articles = generateArticlesHTML(content, false);
+const contentHTML = `
+<main id="main" style="margin-top:80px">
+    <div class="container">
+    ${introHTML}
+    <section id="content">
+        ${articles}
+    </section>
+    </div>
+</main>`;
+
+const canonical = 'https://www.multi-pitch.com' + page;
+const structuredData = `<script type="application/ld+json">${JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://www.multi-pitch.com/" },
+        { "@type": "ListItem", "position": 2, "name": content.heading, "item": canonical }
+    ]
+})}</script>`;
+
+// a fresh copy of the head template per page, so placeholders are still present
+const pageHeadHTML = headHTML
+    .replace(/{{cannonical}}/gi, canonical)
+    .replace(/{{description}}/gi, content.description)
+    .replace(/{{title}}/gi, content.heading)
+    .replace(/<!-- Scripts -->/gi, newScript)
+    .replace(/{{heroJpg}}/gi, 'https://www.multi-pitch.com' + (content.heroImg || '/img/tiles/bosigran-climbing-small.jpg'))
+    .replace(/{{ogType}}/gi, 'article')
+    .replace('<!-- Structured Data -->', structuredData)
+    .replace(`<meta name="climbId" id="climbIdMeta" content="{{id}}" />`, '');
+
+const indexLoc = './website' + page + 'index.html';
+fs.writeFile(indexLoc, pageHeadHTML + navHTML + contentHTML + footerHTML, {encoding:'utf8',flag:'w'}, function (err) {
+    if (err) throw err;
+    console.log(indexLoc + " saved!");
+});

--- a/generateSiteMap.js
+++ b/generateSiteMap.js
@@ -22,6 +22,8 @@ function tipsLastmod(lastUpdated) {
 const blogArticles = JSON.parse(fs.readFileSync('./website/blog/content.json')).articles
     .filter(article => article.publish);
 
+const gradesContent = JSON.parse(fs.readFileSync('./website/climbing-grades/content.json'));
+
 function generate() {
     const blogEntries = blogArticles.map(article => `
         <url>
@@ -65,6 +67,11 @@ function generate() {
             <loc>https://www.multi-pitch.com/map/</loc>
             <lastmod>${date}</lastmod>
             <priority>0.6</priority>
+        </url>
+        <url>
+            <loc>https://www.multi-pitch.com${gradesContent.url}</loc>
+            <lastmod>${tipsLastmod(gradesContent.lastUpdated)}</lastmod>
+            <priority>0.7</priority>
         </url>
         ${blogEntries.join('')}${urlsEntry.join('')}
     </urlset>`;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "generate-climbs": "node generateCardClimb.js",
     "generate-sitemap": "node generateSiteMap.js",
     "generate-blog" : "node generateBlogPages.js",
-    "generate-all": "npm run generate-climbs && npm run generate-sitemap && npm run generate-blog",
+    "generate-content": "node generateContentPages.js",
+    "generate-all": "npm run generate-climbs && npm run generate-sitemap && npm run generate-blog && npm run generate-content",
     "start": "npx serve ./website -l 9000",
     "test": "cypress run --headless",
     "deploy-test": "aws s3 sync website s3://multi-pitch-test.co.uk --delete"

--- a/redirect-rules/s3-rules.xml
+++ b/redirect-rules/s3-rules.xml
@@ -23,12 +23,56 @@
     </RoutingRule>
     <RoutingRule>
         <Condition>
-            <KeyPrefixEquals>climbing-grades/</KeyPrefixEquals>
+            <KeyPrefixEquals>climbing-tips/climbing-grades/</KeyPrefixEquals>
         </Condition>
         <Redirect>
             <Protocol>https</Protocol>
             <HostName>www.multi-pitch.com</HostName>
-            <ReplaceKeyWith>climbing-tips/climbing-grades/</ReplaceKeyWith>
+            <ReplaceKeyWith>climbing-grades/</ReplaceKeyWith>
+            <HttpRedirectCode>301</HttpRedirectCode>
+        </Redirect>
+    </RoutingRule>
+    <RoutingRule>
+        <Condition>
+            <KeyPrefixEquals>climbing-tips/climbing-gear/</KeyPrefixEquals>
+        </Condition>
+        <Redirect>
+            <Protocol>https</Protocol>
+            <HostName>www.multi-pitch.com</HostName>
+            <ReplaceKeyWith>blog/</ReplaceKeyWith>
+            <HttpRedirectCode>301</HttpRedirectCode>
+        </Redirect>
+    </RoutingRule>
+    <RoutingRule>
+        <Condition>
+            <KeyPrefixEquals>climbing-tips/rock-types/</KeyPrefixEquals>
+        </Condition>
+        <Redirect>
+            <Protocol>https</Protocol>
+            <HostName>www.multi-pitch.com</HostName>
+            <ReplaceKeyWith>blog/</ReplaceKeyWith>
+            <HttpRedirectCode>301</HttpRedirectCode>
+        </Redirect>
+    </RoutingRule>
+    <RoutingRule>
+        <Condition>
+            <KeyPrefixEquals>climbing-tips/climbing-terminology/</KeyPrefixEquals>
+        </Condition>
+        <Redirect>
+            <Protocol>https</Protocol>
+            <HostName>www.multi-pitch.com</HostName>
+            <ReplaceKeyWith>blog/</ReplaceKeyWith>
+            <HttpRedirectCode>301</HttpRedirectCode>
+        </Redirect>
+    </RoutingRule>
+    <RoutingRule>
+        <Condition>
+            <KeyPrefixEquals>climbing-tips/</KeyPrefixEquals>
+        </Condition>
+        <Redirect>
+            <Protocol>https</Protocol>
+            <HostName>www.multi-pitch.com</HostName>
+            <ReplaceKeyWith>blog/</ReplaceKeyWith>
             <HttpRedirectCode>301</HttpRedirectCode>
         </Redirect>
     </RoutingRule>

--- a/website/climbing-grades/content.html
+++ b/website/climbing-grades/content.html
@@ -1,0 +1,397 @@
+<div class="big-card" style="color:#111;background: #FFF;">
+    <div class="card-body">
+        <div class="big-card-body" style="margin-top:0;">
+            <h2 id="modalStart" tabindex="0">
+                Change Grading System:
+            </h2>
+            <style>
+                .gradeLabel {
+                    padding: .5rem;
+                    width: 30%;
+                    background-color: #f7f7f7;
+                    border: 1px solid #ccc;
+                    display: inline-flex;
+                    margin: 1%;
+                    min-width: 180px;
+                    transition: background-color .5s ease;
+                }
+
+                .gradeLabel:hover {
+                    background-color: #ccc;
+                }
+
+                @media (max-width: 500px) {
+                    .gradeLabel {
+                        width: 95%;
+                    }
+                }
+            </style>
+            <label class="gradeLabel">
+                <input type="radio" name="gradeChanger" value="BAS" onChange="updateGradePref()" tabindex="0" />
+                British Adjectival
+            </label>
+            <label class="gradeLabel">
+                <input type="radio" name="gradeChanger" value="UIAA" onChange="updateGradePref()" tabindex="0" />
+                <abbr title="Union Internationale des Associations d'Alpinisme">UIAA</abbr>
+            </label>
+            <label class="gradeLabel">
+                <input type="radio" name="gradeChanger" value="YDS" onChange="updateGradePref()" tabindex="0" />
+                <abbr title="Yosemite Decimal System">YDS</abbr>
+            </label>
+            <label class="gradeLabel">
+                <input type="radio" name="gradeChanger" value="FS" onChange="updateGradePref()" tabindex="0" />
+                French Sport
+            </label>
+            <label class="gradeLabel">
+                <input type="radio" name="gradeChanger" value="N" onChange="updateGradePref()" tabindex="0" />
+                Norwegian
+            </label>
+            <label class="gradeLabel">
+                <input type="radio" name="gradeChanger" value="ALP" onChange="updateGradePref()" tabindex="0" />
+                Alpine Grades
+            </label>
+            <br />
+            <p>
+                <small>
+                    <strong>Please Note:</strong>
+                    Climbing grades in theory follow quite logical rules. However in practice they are incredibly
+                    subjective and inconsistent, even within a single climbing grade system. Different
+                    climbing grade systems use very different criteria, which cannot be translated accurately,
+                    so <em style="text-decoration: underline;">don't rely on the converted grade</em>.
+                </small>
+            </p>
+            <label>
+                <input type="checkbox" name="useConverted" id="useConverted" value="true"
+                    onChange="toggleUseConverted()" />
+                Use Converted Grades
+            </label>
+            <style>
+                table{
+                    text-align: center;
+                    margin-left: auto;
+                    margin-right: auto;
+                    min-width:350px;
+                    border-spacing: 0;
+                }
+                thead tr th {
+                    background-color: #222;
+                    color: #FFF;
+                }
+                td{
+                    min-width: 70px;
+                    border:1px solid #222;
+                }
+                tr{
+                    height:25px;
+                }
+                .very-easy.active{
+                    background-color: #a9dfbf; 
+                }
+                .easy.active{
+                    background-color: #d5f5e3;
+                }
+                .easy-medium.active{
+                    background-color: #fcf3cf;
+                }
+                .medium.active{
+                    background-color: #f9e79f;
+                }
+                .medium-hard.active {
+                    background-color: #f5cba7;
+                }
+                .hard.active{
+                    background-color: #f5b7b1;
+                }
+                .very-hard.active{
+                    background-color: #d98880;
+                }
+                .hard-edge.active{
+                    background-color: #b03a2e;
+                }
+            </style>
+            <table id="gradeTable">
+                <thead>
+                    <tr>
+                        <th colspan="2" aria-colspan="2">BAS</th>
+                        <th>UIAA</th>
+                        <th>N</th>
+                        <th>FS</th>
+                        <th>FS simp.</th>
+                        <th>YDS</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <!-- row 1 -->
+                        <td></td>
+                        <td rowspan="2" aria-rowspan="2" class="very-easy active BAS">Diff 3a</td>
+                        <td rowspan="2" aria-rowspan="2" class="very-easy UIAA">II</td>
+                        <td class="very-easy N">2</td>
+                        <td class="very-easy FS">3a</td>
+                        <td rowspan="4" aria-rowspan="4" class="very-easy FS">f3</td>
+                        <td rowspan="2" aria-rowspan="2" class="very-easy YDS">5.3</td>
+                    </tr>
+                    <tr>
+                        <!-- row 2 -->
+                        <td rowspan="2" aria-rowspan="2" class="very-easy active BAS">Diff 3b</td>
+                        <td class="very-easy N">3</td>
+                        <td class="very-easy FS">3b</td>
+                    </tr>
+                    <tr>
+                        <!-- row 3 -->
+                        <td rowspan="2" aria-rowspan="2" class="easy active BAS">VDiff 3b</td>
+                        <td rowspan="3" aria-rowspan="3" class="easy UIAA">III</td>
+                        <td rowspan="2" aria-rowspan="2" class="easy N">4</td>
+                        <td rowspan="2" aria-rowspan="2" class="easy FS">3c</td>
+                        <td rowspan="2" aria-rowspan="2" class="easy YDS">5.4</td>
+                    </tr>
+                    <tr>
+                        <!-- row 4 -->
+                        <td rowspan="2" aria-rowspan="2" class="easy active BAS">VDiff 3c</td>
+                    </tr>
+                    <tr>
+                        <!-- row 5 -->
+                        <td rowspan="2" aria-rowspan="2" class="easy-medium active BAS">Sev 3c</td>
+                        <td rowspan="2" aria-rowspan="2" class="easy-medium N">4+</td>
+                        <td rowspan="2" aria-rowspan="2" class="easy-medium FS">4a</td>
+                        <td rowspan="4" aria-rowspan="4" class="medium FS">f4</td>
+                        <td rowspan="2" aria-rowspan="2" class="easy-medium YDS">5.5</td>
+                    </tr>
+                    <tr>
+                        <!-- row 6 -->
+                        <td rowspan="2" aria-rowspan="2" class="easy-medium active BAS">Sev 4a</td>
+                        <td rowspan="2" aria-rowspan="2" class="easy-medium UIAA">IV</td>
+                    </tr>
+                    <tr>
+                        <!-- row 7 -->                        
+                        <td rowspan="2" aria-rowspan="2" class="medium active BAS">HS 3c</td>                        
+                        <td rowspan="3" aria-rowspan="3" class="medium N">5-</td>
+                        <td rowspan="2" aria-rowspan="2" class="medium FS">4b</td>                        
+                        <td rowspan="2" aria-rowspan="2" class="medium YDS">5.6</td>
+                    </tr>
+                    <tr>
+                        <!-- row 8 -->
+                        <td rowspan="2" aria-rowspan="2" class="medium active BAS">HS 4a</td>
+                        <td rowspan="2" aria-rowspan="2"  class="medium UIAA">IV+</td>
+                    </tr>
+                    <tr>
+                        <!-- row 9 -->
+                        <td rowspan="2" aria-rowspan="2" class="medium active BAS">HS 4b</td>                     
+                        <td rowspan="2" aria-rowspan="2" class="medium FS">4c</td>
+                        <td rowspan="3" aria-rowspan="3" class="medium FS">f4+</td>
+                        <td rowspan="3" aria-rowspan="3" class="medium YDS">5.7</td>
+                    </tr>
+                    <tr>
+                        <!-- row 10 -->
+                        <td rowspan="2" aria-rowspan="2" class="medium-hard active BAS">VS 4b</td>
+                        <td rowspan="3" aria-rowspan="3" class="medium UIAA">V-</td>
+                        <td rowspan="3" aria-rowspan="3" class="medium-hard N">5</td>                                         
+                   </tr>
+                    <tr>
+                        <!-- row 11 -->
+                        <td rowspan="2" aria-rowspan="2" class="medium-hard active BAS">VS 4c</td>                     
+                        <td rowspan="2" aria-rowspan="2" class="medium-hard FS">5a</td>                    
+                    </tr>
+                    <tr>
+                        <!-- row 12 -->
+                        <td rowspan="2" aria-rowspan="2" class="medium-hard active BAS">VS 5a</td>
+                        <td rowspan="3" aria-rowspan="3" class="medium-hard FS">f5</td>
+                        <td rowspan="2" aria-rowspan="2" class="medium-hard YDS">5.8</td>
+                    </tr>
+                    <tr>
+                        <!-- row 13 -->
+                        <td rowspan="2" aria-rowspan="2" class="hard active BAS">HVS 4c</td>
+                        <td rowspan="2" aria-rowspan="2" class="medium-hard UIAA">V+</td>
+                        <td rowspan="3" aria-rowspan="3" class="hard N">5+</td>
+                        <td rowspan="2" aria-rowspan="2" class="hard FS">5b</td>
+                    </tr>
+                    <tr>
+                        <!-- row 14 -->
+                        <td rowspan="2" aria-rowspan="2" class="hard active BAS">HVS 5a</td>
+                        <td rowspan="2" aria-rowspan="2" class="hard YDS">5.9</td>
+                    </tr>
+                    <tr>
+                        <!-- row 15 -->
+                        <td rowspan="2" aria-rowspan="2" class="hard active BAS">HVS 5b</td>
+                        <td rowspan="2" aria-rowspan="2" class="hard UIAA">VI-</td>
+                        <td rowspan="2" aria-rowspan="2" class="hard FS">5c</td>
+                        <td rowspan="2" aria-rowspan="2" class="hard FS">f5+</td>
+                        
+                    </tr>
+                    <tr>
+                        <!-- row 16 -->
+                        <td rowspan="2" aria-rowspan="2" class="very-hard active BAS">E1 5a</td>
+                        <td rowspan="2" aria-rowspan="2" class="hard N">6-</td>
+                        <td rowspan="2" aria-rowspan="2" class="hard YDS">5.10a</td>
+                    </tr>
+                    <tr>
+                        <!-- row 17 -->
+                        <td rowspan="2" aria-rowspan="2" class="very-hard active BAS">E1 5b</td>
+                        <td rowspan="2" aria-rowspan="2" class="very-hard UIAA">VI</td>
+                        <td rowspan="2" aria-rowspan="2" class="very-hard FS">6a</td>
+                        <td rowspan="2" aria-rowspan="2" class="very-hard FS">f6a</td>
+                        
+                    </tr>
+                    <tr>
+                        <!-- row 18 -->
+                        <td rowspan="2" aria-rowspan="2" class="very-hard active BAS">E1 5c</td>
+                        <td rowspan="3" aria-rowspan="3" class="very-hard N">6</td>
+                        <td class="very-hard YDS">5.10b</td>
+                    </tr>
+                    <tr>
+                        <!-- row 19 -->
+                        <td rowspan="2" aria-rowspan="2" class="hard-edge active BAS">E2 5c</td>
+                        <td rowspan="2" aria-rowspan="2" class="very-hard UIAA">VI+</td>
+                        <td rowspan="2" aria-rowspan="2" class="very-hard FS">6a+</td>
+                        <td rowspan="2" aria-rowspan="2" class="very-hard FS">f6a+</td>
+                        <td rowspan="2" aria-rowspan="2" class="very-hard YDS">5.10c</td>
+                    </tr>
+                    <tr>
+                        <!-- row 20 -->
+                        <td></td>
+                    </tr>
+                </tbody>
+            </table>
+            <hr />
+            <br />
+            <section id="BAS" class="gradeDes" style="display: none;">
+                <h3>British Adjectival System</h3>
+                <p>
+                    The British Adjectival System is usually seen as two different grades. An adjectival
+                    grade, for example <abbr title="Very Severe">VS</abbr>, and a technical grade for
+                    example 4b. The adjectival grade is an all-encompassing view of the difficulty of
+                    the climb, essentially a blend of physical and psychological difficulty. This
+                    looks at how hard the moves are, how good the protection is, how
+                    strenuous the overall route is, how loose the rock is etc. The technical grade
+                    simply looks at the hardest move on the route and grades it using the British system,
+                    which is, unfortunately different to the French sport system used in almost all British
+                    climbing walls, making it easy to get confused! For example an English 6a is much,
+                    much harder than a French sport 6a, often shown as f6a.
+                </p>
+                <p>
+                    <strong>Example</strong>: <a href="/climbs/wreakers-slab-on-cornakey-cliff/">Wreakers slab on
+                        Cornakey
+                        Cliff</a> is graded VS 4b. This is an unusually high adjectival grade for such a low
+                    technical grade. On the route the climber will notice a few key factors which lead to the
+                    VS grade. Firstly, it has a lot of loose rock. In addition, protection is not
+                    straightforward or easy to find early on. It’s also tidal, meaning escape down could
+                    be closed for a long time if ascent is not possible. The route has a lot of exposure.
+                    Finally, it’s over 100m long, meaning some endurance is required.
+                    In contrast, <a href="/climbs/doorpost-on-bosigran/">Doorpost at Bosigran</a>, Cornwall,
+                    is also 4b in technical grade, but has an overall adjectival grade of Hard Severe
+                    which is a grade Lower. Doorpost probably has a harder crux on pitch 2, but protection
+                    is good throughout the route and the rock is solid, so overall it has a lower adjectival
+                    grade.
+                </p>
+            </section>
+            <section id="UIAA" class="gradeDes" style="display: none;">
+                <h3>UIAA Scale</h3>
+                <p>
+                    The International Union of Alpine Associations is grading system reasonably common
+                    in mainland Europe. It’s represented by Roman numerals from I through to VII and is
+                    now open ended to X (ten) and beyond. One key advantage of this system is its
+                    <a href="https://www.theuiaa.org/mountaineering/uiaa-grades-for-rock-climbing/" target="blank">clear
+                        descriptions</a> from grades I to VII. Essentially the system grades the hardest
+                    move in the route. However, the system takes no real account of either protection
+                    available or other factors that may impact a climber’s performance like exposure or
+                    altitude. As such the Alpine system or Scale of Global Assessment and French “sport"
+                    systems are both offshoots/additions of the UIAA scale, which itself is developed from
+                    the Welzenbach Scale.
+                </p>
+                <p>
+                    <strong>Example</strong>: The climb <a href="/climbs/esparraguera-on-roca-gris/">Esparraguera
+                        on Roca Gris</a> is graded V+. This speaks to the hardest move, which is pulling up on a jug
+                    on the 3rd pitch. However the climb is also graded f5c, which is a slightly high
+                    conversion. The reason being the French sport system looks at the difficulty of
+                    each pitch (or length of rope) not just the hardest move, but also not the whole
+                    route like the alpine system. The UIAA scale and sport grade say nothing about
+                    the complexity of the route in terms of exposure, loose rock, route finding and
+                    run-out sections. Being comfortable climbing a UIAA V+ or f5c for 30m would be
+                    poor training for this beautifully complex route.
+                </p>
+            </section>
+            <section id="FS" class="gradeDes" style="display: none;">
+                <h3>French Sport Grades</h3>
+                <p>
+                    French numerical grades were originally an offshoot of the UIAA system. In theory
+                    they aim to grade the difficulty of a pitch. However whole routes are given
+                    the grade of the hardest pitch. The scale currently runs from 1 to 9c. Grades
+                    from 3 onwards can be sub divided into a, b & c for example 5c is harder than 5b.
+                    Grades from 6a onwards can additionally have a plus (and occasionally a minus)
+                    added where a 6a+ is harder than a 6a but easier than a 6b. This is the most
+                    common system used for grading sport routes and is used in most lead climbing
+                    gyms in Europe. The major downside to the system is that it doesn’t take into
+                    account protection or rock quality, or even the overall difficulty of multi-pitch
+                    rock climbs.
+                </p>
+                <p>
+                    <strong>Example</strong>: <a href="/climbs/visite-obligatoire-on-aiguille-dibona/">Visite
+                        Obligatoire on the mountain Aiguille Dibona</a> is graded 6a+. It has some tough pitches,
+                    but being able to climb 6a+ in the gym is not going to be enough to get you up all
+                    350m of this route. In fact climbers who can often manage 6c or 7a have failed to
+                    ascend this route. Therefore the alpine adjectival grade of <em>trés difficile</em>
+                    is much more representitive. I.e. it’s a solid E1 in British grades.
+                </p>
+            </section>
+            <section id="YDS" class="gradeDes" style="display: none;">
+                <h3>Yosemite Decimal System</h3>
+                <p>
+                    The Yosemite Decimal System has a lot of complexity to it, most of which isn’t used day
+                    to day. Firstly, the initial number before the decimal indicates the type of terrain
+                    where 4 is roped scrambling and 5 is climbing. 1 would presumably be walking to the
+                    shop. Aid climbs originally started with a 6 but most people don’t use that anymore.
+                    All multi-pitch free climbing will start with a five. 5.4 is easer than 5.9. Once the
+                    scale hits 5.10 then letters a, b, c and d can be added. Ie 5.10a. The system grades
+                    the hardest move, although on modern routes the grades factor in how sustained they are
+                    as well.
+                </p>
+                <p>
+                    <strong>Example</strong>: The climb <a href="/climbs/joy-on-mount-indefatigable/">Joy on
+                        Mount Indefatigable</a> is graded around 5.7. The grade band between 5.5 and 5.9 is pretty
+                    tight, in addition, because the Yosemite Decimal system looks at the hardest move, you
+                    can easily add 2 grades to the climb by taking a tiny variation on one pitch. The
+                    route joy is between 5.6 and 5.8 on the YDS scale.
+                </p>
+            </section>
+            <section id="N" class="gradeDes" style="display: none;">
+                <h3>Norwegian Grades</h3>
+                <p>
+                    The Norwegian Grading system started out as the UIAA system but as climbing
+                    progressed up to and then past the original ceiling of the sixth grade,
+                    the Norwegian system diverged. It switched to using Arabic numbers eg. 6
+                    rather than Roman Numerals eg VI. The main difference is, grades tend to be
+                    slightly harder at around the fifth grade and beyond.
+                </p>
+                <p>
+                    <strong>Example</strong>: The <a href="/climbs/sydpillaren-on-stetind/">South Pillar
+                        climb on Stetind </a> is graded around 6-. This makes the route somewhere between
+                    HVS and E1. Given the length and seriousness of the route E1 is the appropriate
+                    conversion to British grades, but it is a full VI on the UIAA scale.
+                </p>
+            </section>
+            <section id="ALP" class="gradeDes" style="display: none;">
+                <h3>Alpine Scale</h3>
+                <p>
+                    The Scale of Global Assessment, usually called the Alpine Scale, gives an overall
+                    adjectival grade to climbing routes much like the British system. This fills
+                    the gap in the UIAA and sport grading systems where the grade says little about
+                    the seriousness of the route. The system uses French terms and runs from F for
+                    facile (easy in English) to ED for extrêmement difficile (extremely difficult)
+                    ED is open ended with numbers to ED4.
+                </p>
+                <p>
+                    <strong>Example</strong>: <a href="/climbs/visite-obligatoire-on-aiguille-dibona/">Visite
+                        Obligatoire on the mountain Aiguille Dibona</a> is graded TD. TD is described as Very hard,
+                    routes at this grades are serious undertakings with high level of objective danger...
+                    Rock climbing at UIAA grade V and VI with possible aid, very long sections of hard
+                    climbing. The alpine adjectival grade of <em>trés difficile</em> is a solid E1 in
+                    British grades.
+                </p>
+            </section>
+            <a class="open-tile" href="/" onclick="hideTile(false);return false"
+               >
+                <i class="icon-cancel"></i> Close Overlay
+            </a>
+        </div>
+    </div>
+</div>

--- a/website/climbing-grades/content.json
+++ b/website/climbing-grades/content.json
@@ -1,0 +1,96 @@
+{
+ "heading" : "Climbing Grades & Conversion between grades",
+ "navLink" : "Climbing Grades",
+ "intro" : "Climbing grades in theory follow quite logical rules. However in practice they are incredibly subjective and inconsistent, even within a single climbing grade system. Different climbing grade systems use very different criteria, which cannot be translated accurately, so don't rely on the converted grade. <br /><style>\r\n table{\r\n text-align: center;\r\n margin-left: auto;\r\n margin-right: auto;\r\n min-width:350px;\r\n border-spacing: 0;\r\n }\r\n thead tr th {\r\n background-color: #222;\r\n color: #FFF;\r\n }\r\n td{\r\n min-width: 70px;\r\n border:1px solid #222;\r\n }\r\n tr{\r\n height:25px;\r\n }\r\n .very-easy.active{\r\n background-color: #a9dfbf; \r\n }\r\n .easy.active{\r\n background-color: #d5f5e3;\r\n }\r\n .easy-medium.active{\r\n background-color: #fcf3cf;\r\n }\r\n .medium.active{\r\n background-color: #f9e79f;\r\n }\r\n .medium-hard.active {\r\n background-color: #f5cba7;\r\n }\r\n .hard.active{\r\n background-color: #f5b7b1;\r\n }\r\n .very-hard.active{\r\n background-color: #d98880;\r\n }\r\n .hard-edge.active{\r\n background-color: #b03a2e;\r\n }\r\n <\/style>\r\n <table id=\"gradeTable\">\r\n <thead>\r\n <tr>\r\n <th colspan=\"2\" aria-colspan=\"2\">BAS<\/th>\r\n <th>UIAA<\/th>\r\n <th>N<\/th>\r\n <th>FS<\/th>\r\n <th>FS simp.<\/th>\r\n <th>YDS<\/th>\r\n <\/tr>\r\n <\/thead>\r\n <tbody>\r\n <tr>\r\n <!-- row 1 -->\r\n <td><\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-easy active BAS\">Diff 3a<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-easy UIAA\">II<\/td>\r\n <td class=\"very-easy N\">2<\/td>\r\n <td class=\"very-easy FS\">3a<\/td>\r\n <td rowspan=\"4\" aria-rowspan=\"4\" class=\"very-easy FS\">f3<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-easy YDS\">5.3<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 2 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-easy active BAS\">Diff 3b<\/td>\r\n <td class=\"very-easy N\">3<\/td>\r\n <td class=\"very-easy FS\">3b<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 3 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"easy active BAS\">VDiff 3b<\/td>\r\n <td rowspan=\"3\" aria-rowspan=\"3\" class=\"easy UIAA\">III<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"easy N\">4<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"easy FS\">3c<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"easy YDS\">5.4<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 4 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"easy active BAS\">VDiff 3c<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 5 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"easy-medium active BAS\">Sev 3c<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"easy-medium N\">4+<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"easy-medium FS\">4a<\/td>\r\n <td rowspan=\"4\" aria-rowspan=\"4\" class=\"medium FS\">f4<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"easy-medium YDS\">5.5<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 6 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"easy-medium active BAS\">Sev 4a<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"easy-medium UIAA\">VI<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 7 --> \r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium active BAS\">HS 3c<\/td> \r\n <td rowspan=\"3\" aria-rowspan=\"3\" class=\"medium N\">5-<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium FS\">4b<\/td> \r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium YDS\">5.6<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 8 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium active BAS\">HS 4a<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium UIAA\">IV+<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 9 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium active BAS\">HS 4b<\/td> \r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium FS\">4c<\/td>\r\n <td rowspan=\"3\" aria-rowspan=\"3\" class=\"medium FS\">f4+<\/td>\r\n <td rowspan=\"3\" aria-rowspan=\"3\" class=\"medium YDS\">5.7<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 10 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium-hard active BAS\">VS 4b<\/td>\r\n <td rowspan=\"3\" aria-rowspan=\"3\" class=\"medium UIAA\">V-<\/td>\r\n <td rowspan=\"3\" aria-rowspan=\"3\" class=\"medium-hard N\">5<\/td>  \r\n <\/tr>\r\n <tr>\r\n <!-- row 11 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium-hard active BAS\">VS 4c<\/td> \r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium-hard FS\">5a<\/td> \r\n <\/tr>\r\n <tr>\r\n <!-- row 12 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium-hard active BAS\">VS 5a<\/td>\r\n <td rowspan=\"3\" aria-rowspan=\"3\" class=\"medium-hard FS\">f5<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium-hard YDS\">5.8<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 13 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"hard active BAS\">HVS 4c<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"medium-hard UIAA\">V+<\/td>\r\n <td rowspan=\"3\" aria-rowspan=\"3\" class=\"hard N\">5+<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"hard FS\">5b<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 14 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"hard active BAS\">HVS 5a<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"hard YDS\">5.9<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 15 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"hard active BAS\">HVS 5b<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"hard UIAA\">VI-<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"hard FS\">5c<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"hard FS\">f5+<\/td>\r\n \r\n <\/tr>\r\n <tr>\r\n <!-- row 16 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-hard active BAS\">E1 5a<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"hard N\">6-<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"hard YDS\">5.10a<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 17 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-hard active BAS\">E1 5b<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-hard UIAA\">V<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-hard FS\">6a<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-hard FS\">f6a<\/td>\r\n \r\n <\/tr>\r\n <tr>\r\n <!-- row 18 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-hard active BAS\">E1 5c<\/td>\r\n <td rowspan=\"3\" aria-rowspan=\"3\" class=\"very-hard N\">6<\/td>\r\n <td class=\"very-hard YDS\">5.10b<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 19 -->\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"hard-edge active BAS\">E2 5c<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-hard UIAA\">VI+<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-hard FS\">6a+<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-hard FS\">f6a+<\/td>\r\n <td rowspan=\"2\" aria-rowspan=\"2\" class=\"very-hard YDS\">5.10c<\/td>\r\n <\/tr>\r\n <tr>\r\n <!-- row 20 -->\r\n <td><\/td>\r\n <\/tr>\r\n <\/tbody>\r\n <\/table>",
+ "description" : "Understand climbing grades. Climbing grades in theory follow quite logical rules, in practice they are inconsistent, even within a single climbing grade system.",
+ "lastUpdated" : "31/03/2020",
+ "url" : "/climbing-grades/",
+ "heroImg" : "/img/other/mountain-terminology.jpg",
+ "search" : false,
+ "articles" : [
+ {
+ "publish" : true,
+ "title" : "British Adjectival System",
+ "paragraph" : "The British Adjectival System is usually seen as two different grades. An adjectival grade, for example <abbr title=\"Very Severe\">VS</abbr>, and a technical grade for example 4b. The adjectival grade is an all-encompassing view of the difficulty of the climb. This looks at how hard the moves are, how good the protection is, how strenuous the overall route is, how loose the rock is etc. The technical grade simply looks at the hardest move on the route and grades it using the British system, which is, unfortunately different to the French sport system used in almost all British climbing walls, making it easy to get confused! For example an English 6a is much, much harder than a French sport 6a, often shown as f6a. <br /><strong>Example</strong>: <a href=\"/climbs/wreakers-slab-on-cornakey-cliff/\">Wreakers slab on Cornakey Cliff</a> is graded VS 4b. This is an unusually high adjectival grade for such a low technical grade. On the route the climber will notice a few key factors which lead to the VS grade. Firstly, it has a lot of loose rock. In addition, protection is not straightforward or easy to find early on. It’s also tidal, meaning escape down could be closed for a long time if ascent is not possible. The route has a lot of exposure. Finally, it’s over 100m long, meaning some endurance is required. In contrast, <a href=\"/climbs/doorpost-on-bosigran/\">Doorpost at Bosigran</a>, Cornwall, is also 4b in technical grade, but has an overall adjectival grade of Hard Severe which is a grade Lower. Doorpost probably has a harder crux on pitch 2, but protection is good throughout the route and the rock is solid, so overall it has a lower adjectival grade.",
+ "img" : {
+ "url" : "/img/other/grades/weakers-slab-in-north-cornwall.jpg",
+ "alt": "VS climbing in North Cornwall"
+ },
+ "link" : {
+ "href" : "/climbs/wreakers-slab-on-cornakey-cliff/",
+ "text" : "Wreakers Slab on Cornakey Cliff graded VS 4b",
+ "pushable" : false
+ }
+ },
+ {
+ "publish" : true,
+ "title" : "UIAA Scale",
+ "paragraph" : "The International Union of Alpine Associations, or UIAA grading system, is reasonably common in mainland Europe. It’s represented by Roman numerals from I through to VII and is now open ended to X (ten) and beyond. One key advantage of this system is its <a href=\"https://www.theuiaa.org/mountaineering/uiaa-grades-for-rock-climbing/\" target=\"blank\">clear descriptions</a> from grades I to VII. Essentially the system grades the hardest move in the route. However, the system takes no real account of either protection available or other factors that may impact a climber’s performance like exposure or altitude. As such the Alpine system or Scale of Global Assessment and French <em>sport</em> systems are both offshoots/additions of the UIAA scale, which itself is developed from the Welzenbach Scale.<br /><strong>Example</strong>: The climb <a href=\"/climbs/esparraguera-on-roca-gris/\">Esparraguera on Roca Gris</a> is graded V+. This speaks to the hardest move, which is pulling up on a jug on the 3rd pitch. However the climb is also graded f5c, which is a slightly high conversion. The reason being the French sport system looks at the difficulty of each pitch (or length of rope) not just the hardest move, but also not the whole route like the alpine system. The UIAA scale and sport grade say nothing about the complexity of the route in terms of exposure, loose rock, route finding and run-out sections. Being comfortable climbing a UIAA V+ or f5c for 30m would be poor training for this beautifully complex route.",
+ "img" : {
+ "url" : "/img/other/grades/roca-gris-in-montserrat-spain.jpg",
+ "alt": "Grade V+ climb in Montserrat Spain"
+ },
+ "link" : {
+ "href" : "/climbs/esparraguera-on-roca-gris/",
+ "text" : "The climb Esparraguera on Grey Rock graded UIAA V+",
+ "pushable" : false
+ }
+ },
+ {
+ "publish" : true,
+ "title" : "Yosemite Decimal System",
+ "paragraph" : "The Yosemite Decimal System has a lot of complexity to it, most of which isn’t used day to day. Firstly, the initial number before the decimal indicates the type of terrain where 4 is roped scrambling and 5 is climbing. 1 would presumably be walking to the shop. Aid climbs originally started with a 6 but most people don’t use that anymore. All multi-pitch free climbing will start with a five. 5.4 is easer than 5.9. Once the scale hits 5.10 then letters a, b, c and d can be added. Ie 5.10a. The system grades the hardest move, although on modern routes the grades factor in how sustained they are as well. <br /> <strong>Example</strong>: The climb <a href=\"/climbs/joy-on-mount-indefatigable/\">Joy on Mount Indefatigable</a> is graded around 5.7. The grade band between 5.5 and 5.9 is pretty tight, in addition, because the Yosemite Decimal system looks at the hardest move, you can easily add 2 grades to the climb by taking a tiny variation on one pitch. The route joy is between 5.6 and 5.8 on the YDS scale.",
+ "img" : {
+ "url" : "/img/other/grades/joy-climb-in-canada.jpg",
+ "alt": "Joy, A classic climb in Canada"
+ },
+ "link" : {
+ "href" : "/climbs/joy-on-mount-indefatigable/",
+ "text" : "The climb Joy gradded between 5.7 & 5.9 on the Yosemite Decimal System",
+ "pushable" : false
+ }
+ },
+ {
+ "publish" : true,
+ "title" : "French Sport Grades",
+ "paragraph" : "French numerical grades were originally an offshoot of the UIAA system. In theorythey aim to grade the difficulty of a pitch. However whole routes are given the grade of the hardest pitch. The scale currently runs from 1 to 9c. Grades from 3 onwards can be sub divided into a, b & c for example 5c is harder than 5b. Grades from 6a onwards can additionally have a plus (and occasionally a minus) added where a 6a+ is harder than a 6a but easier than a 6b. This is the most common system used for grading sport routes and is used in most lead climbing gyms in Europe. The major downside to the system is that it doesn’t take into account protection or rock quality, or even the overall difficulty of multi-pitch rock climbs.<br /><strong>Example</strong>: <a href=\"/climbs/visite-obligatoire-on-aiguille-dibona/\">Visite Obligatoire on the mountain Aiguille Dibona</a> is graded 6a+. It has some tough pitches,but being able to climb 6a+ in the gym is not going to be enough to get you up all 350m of this route. In fact climbers who can often manage 6c or 7a have failed to ascend this route. Therefore the alpine adjectival grade of <em>trés difficile</em> is much more representitive. I.e. it’s a solid E1 in British grades. The route Direkte Plattenwand on Brüggler in Switzerland is largely bolted and so a sport grade here is more useful.",
+ "img" : {
+ "url" : "/img/other/grades/bruggler-offers-great-climbing-in-switzerland.jpg",
+ "alt": "Brüggler in Switzerland uses French grades."
+ },
+ "link" : {
+ "href" : "/climbs/direkte-plattenwand-on-brüggler/",
+ "text" : "Climbing the center of Brüggler is graded 5a ",
+ "pushable" : false
+ }
+ },
+ {
+ "publish" : true,
+ "title" : "Norwegian Grades",
+ "paragraph" : "The Norwegian Grading system started out as the UIAA system but as climbing progressed up to and then past the original ceiling of the sixth grade, the Norwegian system diverged. It switched to using Arabic numbers ie. 6 rather than Roman Numerals ie VI. The main difference is, grades tend to be slightly harder at around the fifth grade and beyond.<br /><strong>Example</strong>: The <a href=\"/climbs/sydpillaren-on-stetind/\">South Pillar climb on Stetind </a> is graded around 6-. This makes the route somewhere between HVS and E1. Given the length and seriousness of the route E1 is possibly the more appropriate conversion to British grades, but it is a full VI on the UIAA scale.",
+ "img" : {
+ "url" : "/img/other/grades/stetind-climb-in-norway.jpg",
+ "alt": "Stetind is Norways national mountain"
+ },
+ "link" : {
+ "href" : "/climbs/sydpillaren-on-stetind/",
+ "text" : "Graded 6- on the Norwegian scale, The South pillar climb on Stetind is breathtaking",
+ "pushable" : false
+ }
+ },
+ {
+ "publish" : true,
+ "title" : "Alpine Scale",
+ "paragraph" : "The Scale of Global Assessment, usually called the Alpine Scale, gives an overall adjectival grade to climbing routes much like the British system. This fills the gap in the UIAA and sport grading systems where the grade says little about the seriousness of the route. The system uses French terms and runs from F for facile (easy in English) to ED for extrêmement difficile (extremely difficult) ED is open ended with numbers to ED4.<br /><strong>Example</strong>: <a href=\"/climbs/visite-obligatoire-on-aiguille-dibona/\">Visite Obligatoire on the mountain Aiguille Dibona</a> is graded TD. TD is described as Very hard. Routes at this grades are serious undertakings with high level of objective danger... Rock climbing at UIAA grade V and VI with possible aid, very long sections of hard climbing. The alpine adjectival grade of <em>trés difficile</em> is a solid E1 in British grades.",
+ "img" : {
+ "url" : "/img/other/grades/aiguille-debona.jpg",
+ "alt": "Aiguille Dibona, named after the Italian Mountaineer"
+ },
+ "link" : {
+ "href" : "/climbs/visite-obligatoire-on-aiguille-dibona/",
+ "text" : "The Obligatory Visit on Aiguille Dibona is graded trés difficile",
+ "pushable" : false
+ }
+ }
+ ]
+} 

--- a/website/climbing-grades/index.html
+++ b/website/climbing-grades/index.html
@@ -1,0 +1,466 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        window.performance.mark('start');
+    </script>
+    <script src="/js/theme-init.js"></script>
+
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <link rel="canonical" href="https://www.multi-pitch.com/climbing-grades/" />
+    
+    <link rel="preconnect" href="https://s3-eu-west-1.amazonaws.com/" />
+    <link rel="preconnect" href="https://www.google-analytics.com" />
+    <link rel="preconnect" href="https://www.googletagmanager.com" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preload" href="/css/fontello.css" as="style" />
+
+    <title>Climbing Grades & Conversion between grades</title>
+    <meta name="description" content="Understand climbing grades. Climbing grades in theory follow quite logical rules, in practice they are inconsistent, even within a single climbing grade system." />
+    
+
+    <!-- Styles -->
+    <link href="/css/style.css" rel="stylesheet" />
+
+    <!--scripts -->
+<script src="/components/article.js" type="module"></script>
+<script>
+    window.addEventListener('DOMContentLoaded', (event) => {
+        makeLinksPushable();
+    });
+</script>
+    <script src="/js/main.js" type="module"></script>
+
+    <!-- Favicons -->
+    <link rel="apple-touch-icon" sizes="57x57" href="/img/favicon/apple-icon-57x57.png" />
+    <link rel="apple-touch-icon" sizes="60x60" href="/img/favicon/apple-icon-60x60.png" />
+    <link rel="apple-touch-icon" sizes="72x72" href="/img/favicon/apple-icon-72x72.png" />
+    <link rel="apple-touch-icon" sizes="76x76" href="/img/favicon/apple-icon-76x76.png" />
+    <link rel="apple-touch-icon" sizes="114x114" href="/img/favicon/apple-icon-114x114.png" />
+    <link rel="apple-touch-icon" sizes="120x120" href="/img/favicon/apple-icon-120x120.png" />
+    <link rel="apple-touch-icon" sizes="144x144" href="/img/favicon/apple-icon-144x144.png" />
+    <link rel="apple-touch-icon" sizes="152x152" href="/img/favicon/apple-icon-152x152.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/img/favicon/apple-icon-180x180.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/img/favicon/android-icon-192x192.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="96x96" href="/img/favicon/favicon-96x96.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/img/favicon/favicon-16x16.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="msapplication-TileColor" content="#ffffff" />
+    <meta name="msapplication-TileImage" content="/img/favicon/ms-icon-144x144.png" />
+    <meta name="theme-color" content="#ffffff" />
+
+    <!-- Sharing Tags -->
+    <meta property="og:site_name" content="Multi-Pitch" />
+    <meta property="og:title" content="Climbing Grades & Conversion between grades" />
+    <meta property="og:description"
+          content="Understand climbing grades. Climbing grades in theory follow quite logical rules, in practice they are inconsistent, even within a single climbing grade system." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.multi-pitch.com/climbing-grades/" />
+    <meta property="og:image" content="https://www.multi-pitch.com/img/other/mountain-terminology.jpg" />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Climbing Grades & Conversion between grades" />
+    <meta name="twitter:description" content="Understand climbing grades. Climbing grades in theory follow quite logical rules, in practice they are inconsistent, even within a single climbing grade system." />
+    <meta name="twitter:image" content="https://www.multi-pitch.com/img/other/mountain-terminology.jpg" />
+
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.multi-pitch.com/"},{"@type":"ListItem","position":2,"name":"Climbing Grades & Conversion between grades","item":"https://www.multi-pitch.com/climbing-grades/"}]}</script>
+
+</head><body id="bdy">
+<!-- Navbar -->
+<nav>
+    <div class="container">
+        <a class="navbar-brand" href="/">
+            <img src="/img/logo/mp-logo-white.png" style="width:30px;" alt="multi-pitch logo" />
+        </a>
+        <ul>
+            <li>
+                <a href="/">Find <span class="not-mobile">A Climb</span></a>
+            </li>
+            <li>
+                <a href="/map/">Map <span class="not-mobile">View</span></a>
+            </li>
+            <li>
+                <a href="/about/">About <span class="not-mobile">&amp; Contact Us</span></a>
+            </li>
+            <li>
+                <a href="/blog/" class="last-nav"><span class="not-mobile">Our </span>Blog</a>
+            </li>
+        </ul>
+    </div>
+</nav>
+<main id="main" style="margin-top:80px">
+    <div class="container">
+    
+<section>
+    <div class="row">
+    <div class="col col-md-12">
+        <h1>Climbing Grades & Conversion between grades</h1>
+    </div>
+    </div>        
+    <div class="row">
+        <div class="col">
+            <p id="intro">Climbing grades in theory follow quite logical rules. However in practice they are incredibly subjective and inconsistent, even within a single climbing grade system. Different climbing grade systems use very different criteria, which cannot be translated accurately, so don't rely on the converted grade. <br /><style>
+ table{
+ text-align: center;
+ margin-left: auto;
+ margin-right: auto;
+ min-width:350px;
+ border-spacing: 0;
+ }
+ thead tr th {
+ background-color: #222;
+ color: #FFF;
+ }
+ td{
+ min-width: 70px;
+ border:1px solid #222;
+ }
+ tr{
+ height:25px;
+ }
+ .very-easy.active{
+ background-color: #a9dfbf; 
+ }
+ .easy.active{
+ background-color: #d5f5e3;
+ }
+ .easy-medium.active{
+ background-color: #fcf3cf;
+ }
+ .medium.active{
+ background-color: #f9e79f;
+ }
+ .medium-hard.active {
+ background-color: #f5cba7;
+ }
+ .hard.active{
+ background-color: #f5b7b1;
+ }
+ .very-hard.active{
+ background-color: #d98880;
+ }
+ .hard-edge.active{
+ background-color: #b03a2e;
+ }
+ </style>
+ <table id="gradeTable">
+ <thead>
+ <tr>
+ <th colspan="2" aria-colspan="2">BAS</th>
+ <th>UIAA</th>
+ <th>N</th>
+ <th>FS</th>
+ <th>FS simp.</th>
+ <th>YDS</th>
+ </tr>
+ </thead>
+ <tbody>
+ <tr>
+ <!-- row 1 -->
+ <td></td>
+ <td rowspan="2" aria-rowspan="2" class="very-easy active BAS">Diff 3a</td>
+ <td rowspan="2" aria-rowspan="2" class="very-easy UIAA">II</td>
+ <td class="very-easy N">2</td>
+ <td class="very-easy FS">3a</td>
+ <td rowspan="4" aria-rowspan="4" class="very-easy FS">f3</td>
+ <td rowspan="2" aria-rowspan="2" class="very-easy YDS">5.3</td>
+ </tr>
+ <tr>
+ <!-- row 2 -->
+ <td rowspan="2" aria-rowspan="2" class="very-easy active BAS">Diff 3b</td>
+ <td class="very-easy N">3</td>
+ <td class="very-easy FS">3b</td>
+ </tr>
+ <tr>
+ <!-- row 3 -->
+ <td rowspan="2" aria-rowspan="2" class="easy active BAS">VDiff 3b</td>
+ <td rowspan="3" aria-rowspan="3" class="easy UIAA">III</td>
+ <td rowspan="2" aria-rowspan="2" class="easy N">4</td>
+ <td rowspan="2" aria-rowspan="2" class="easy FS">3c</td>
+ <td rowspan="2" aria-rowspan="2" class="easy YDS">5.4</td>
+ </tr>
+ <tr>
+ <!-- row 4 -->
+ <td rowspan="2" aria-rowspan="2" class="easy active BAS">VDiff 3c</td>
+ </tr>
+ <tr>
+ <!-- row 5 -->
+ <td rowspan="2" aria-rowspan="2" class="easy-medium active BAS">Sev 3c</td>
+ <td rowspan="2" aria-rowspan="2" class="easy-medium N">4+</td>
+ <td rowspan="2" aria-rowspan="2" class="easy-medium FS">4a</td>
+ <td rowspan="4" aria-rowspan="4" class="medium FS">f4</td>
+ <td rowspan="2" aria-rowspan="2" class="easy-medium YDS">5.5</td>
+ </tr>
+ <tr>
+ <!-- row 6 -->
+ <td rowspan="2" aria-rowspan="2" class="easy-medium active BAS">Sev 4a</td>
+ <td rowspan="2" aria-rowspan="2" class="easy-medium UIAA">VI</td>
+ </tr>
+ <tr>
+ <!-- row 7 --> 
+ <td rowspan="2" aria-rowspan="2" class="medium active BAS">HS 3c</td> 
+ <td rowspan="3" aria-rowspan="3" class="medium N">5-</td>
+ <td rowspan="2" aria-rowspan="2" class="medium FS">4b</td> 
+ <td rowspan="2" aria-rowspan="2" class="medium YDS">5.6</td>
+ </tr>
+ <tr>
+ <!-- row 8 -->
+ <td rowspan="2" aria-rowspan="2" class="medium active BAS">HS 4a</td>
+ <td rowspan="2" aria-rowspan="2" class="medium UIAA">IV+</td>
+ </tr>
+ <tr>
+ <!-- row 9 -->
+ <td rowspan="2" aria-rowspan="2" class="medium active BAS">HS 4b</td> 
+ <td rowspan="2" aria-rowspan="2" class="medium FS">4c</td>
+ <td rowspan="3" aria-rowspan="3" class="medium FS">f4+</td>
+ <td rowspan="3" aria-rowspan="3" class="medium YDS">5.7</td>
+ </tr>
+ <tr>
+ <!-- row 10 -->
+ <td rowspan="2" aria-rowspan="2" class="medium-hard active BAS">VS 4b</td>
+ <td rowspan="3" aria-rowspan="3" class="medium UIAA">V-</td>
+ <td rowspan="3" aria-rowspan="3" class="medium-hard N">5</td>  
+ </tr>
+ <tr>
+ <!-- row 11 -->
+ <td rowspan="2" aria-rowspan="2" class="medium-hard active BAS">VS 4c</td> 
+ <td rowspan="2" aria-rowspan="2" class="medium-hard FS">5a</td> 
+ </tr>
+ <tr>
+ <!-- row 12 -->
+ <td rowspan="2" aria-rowspan="2" class="medium-hard active BAS">VS 5a</td>
+ <td rowspan="3" aria-rowspan="3" class="medium-hard FS">f5</td>
+ <td rowspan="2" aria-rowspan="2" class="medium-hard YDS">5.8</td>
+ </tr>
+ <tr>
+ <!-- row 13 -->
+ <td rowspan="2" aria-rowspan="2" class="hard active BAS">HVS 4c</td>
+ <td rowspan="2" aria-rowspan="2" class="medium-hard UIAA">V+</td>
+ <td rowspan="3" aria-rowspan="3" class="hard N">5+</td>
+ <td rowspan="2" aria-rowspan="2" class="hard FS">5b</td>
+ </tr>
+ <tr>
+ <!-- row 14 -->
+ <td rowspan="2" aria-rowspan="2" class="hard active BAS">HVS 5a</td>
+ <td rowspan="2" aria-rowspan="2" class="hard YDS">5.9</td>
+ </tr>
+ <tr>
+ <!-- row 15 -->
+ <td rowspan="2" aria-rowspan="2" class="hard active BAS">HVS 5b</td>
+ <td rowspan="2" aria-rowspan="2" class="hard UIAA">VI-</td>
+ <td rowspan="2" aria-rowspan="2" class="hard FS">5c</td>
+ <td rowspan="2" aria-rowspan="2" class="hard FS">f5+</td>
+ 
+ </tr>
+ <tr>
+ <!-- row 16 -->
+ <td rowspan="2" aria-rowspan="2" class="very-hard active BAS">E1 5a</td>
+ <td rowspan="2" aria-rowspan="2" class="hard N">6-</td>
+ <td rowspan="2" aria-rowspan="2" class="hard YDS">5.10a</td>
+ </tr>
+ <tr>
+ <!-- row 17 -->
+ <td rowspan="2" aria-rowspan="2" class="very-hard active BAS">E1 5b</td>
+ <td rowspan="2" aria-rowspan="2" class="very-hard UIAA">V</td>
+ <td rowspan="2" aria-rowspan="2" class="very-hard FS">6a</td>
+ <td rowspan="2" aria-rowspan="2" class="very-hard FS">f6a</td>
+ 
+ </tr>
+ <tr>
+ <!-- row 18 -->
+ <td rowspan="2" aria-rowspan="2" class="very-hard active BAS">E1 5c</td>
+ <td rowspan="3" aria-rowspan="3" class="very-hard N">6</td>
+ <td class="very-hard YDS">5.10b</td>
+ </tr>
+ <tr>
+ <!-- row 19 -->
+ <td rowspan="2" aria-rowspan="2" class="hard-edge active BAS">E2 5c</td>
+ <td rowspan="2" aria-rowspan="2" class="very-hard UIAA">VI+</td>
+ <td rowspan="2" aria-rowspan="2" class="very-hard FS">6a+</td>
+ <td rowspan="2" aria-rowspan="2" class="very-hard FS">f6a+</td>
+ <td rowspan="2" aria-rowspan="2" class="very-hard YDS">5.10c</td>
+ </tr>
+ <tr>
+ <!-- row 20 -->
+ <td></td>
+ </tr>
+ </tbody>
+ </table></p>
+        </div>
+    </div>
+    <form id="search" style="display:none;" role="search">
+    <label for="articleSearch" class="sr-only">Search articles</label>
+    <input type="text" id="articleSearch" placeholder="Search" style="width:100%;padding:10px;font-size:1.6rem;">
+    </form>
+    
+    <div id="breadcrumb">
+        <a href="/">Home</a> /
+        <a href="/climbing-grades/" class="pushable" id="thirdLvl">Climbing grades</a>
+    </div>
+</section>
+<hr>
+    <section id="content">
+        <article class="row">
+            <h2 class="col-12">British Adjectival System</h2>
+            <div class="col-12 col-md-4 col-sm-5 col-lg-3">
+                <figure class="compend-fig" tabindex="0" onkeydown="return event.code != 'Enter' || openLightBox('/img/other/grades/weakers-slab-in-north-cornwall.jpg', 'VS climbing in North Cornwall')"
+                    onclick="openLightBox('/img/other/grades/weakers-slab-in-north-cornwall.jpg', 'VS climbing in North Cornwall')">
+                    <picture>    
+                        <source srcset="/img/other/grades/weakers-slab-in-north-cornwall-s.webp" type="image/webp" >
+                        <source srcset="/img/other/grades/weakers-slab-in-north-cornwall-s.jpg" type="image/jpg" >
+                        <img src="/img/other/grades/weakers-slab-in-north-cornwall-s.jpg" alt="VS climbing in North Cornwall" class="cat-img" loading="lazy"/>
+                    </picture>
+                    <figcaption>VS climbing in North Cornwall</figcaption>
+                </figure>
+            </div>
+            <p class="col-12 col-md-8 col-sm-7 col-lg-9">
+                The British Adjectival System is usually seen as two different grades. An adjectival grade, for example <abbr title="Very Severe">VS</abbr>, and a technical grade for example 4b. The adjectival grade is an all-encompassing view of the difficulty of the climb. This looks at how hard the moves are, how good the protection is, how strenuous the overall route is, how loose the rock is etc. The technical grade simply looks at the hardest move on the route and grades it using the British system, which is, unfortunately different to the French sport system used in almost all British climbing walls, making it easy to get confused! For example an English 6a is much, much harder than a French sport 6a, often shown as f6a. <br /><strong>Example</strong>: <a href="/climbs/wreakers-slab-on-cornakey-cliff/">Wreakers slab on Cornakey Cliff</a> is graded VS 4b. This is an unusually high adjectival grade for such a low technical grade. On the route the climber will notice a few key factors which lead to the VS grade. Firstly, it has a lot of loose rock. In addition, protection is not straightforward or easy to find early on. It’s also tidal, meaning escape down could be closed for a long time if ascent is not possible. The route has a lot of exposure. Finally, it’s over 100m long, meaning some endurance is required. In contrast, <a href="/climbs/doorpost-on-bosigran/">Doorpost at Bosigran</a>, Cornwall, is also 4b in technical grade, but has an overall adjectival grade of Hard Severe which is a grade Lower. Doorpost probably has a harder crux on pitch 2, but protection is good throughout the route and the rock is solid, so overall it has a lower adjectival grade. <br /> <a class="seperated-link " href="/climbs/wreakers-slab-on-cornakey-cliff/">Wreakers Slab on Cornakey Cliff graded VS 4b &#8250;</a>
+            </p>
+        </article><article class="row">
+            <h2 class="col-12">UIAA Scale</h2>
+            <div class="col-12 col-md-4 col-sm-5 col-lg-3">
+                <figure class="compend-fig" tabindex="0" onkeydown="return event.code != 'Enter' || openLightBox('/img/other/grades/roca-gris-in-montserrat-spain.jpg', 'Grade V+ climb in Montserrat Spain')"
+                    onclick="openLightBox('/img/other/grades/roca-gris-in-montserrat-spain.jpg', 'Grade V+ climb in Montserrat Spain')">
+                    <picture>    
+                        <source srcset="/img/other/grades/roca-gris-in-montserrat-spain-s.webp" type="image/webp" >
+                        <source srcset="/img/other/grades/roca-gris-in-montserrat-spain-s.jpg" type="image/jpg" >
+                        <img src="/img/other/grades/roca-gris-in-montserrat-spain-s.jpg" alt="Grade V+ climb in Montserrat Spain" class="cat-img" loading="lazy"/>
+                    </picture>
+                    <figcaption>Grade V+ climb in Montserrat Spain</figcaption>
+                </figure>
+            </div>
+            <p class="col-12 col-md-8 col-sm-7 col-lg-9">
+                The International Union of Alpine Associations, or UIAA grading system, is reasonably common in mainland Europe. It’s represented by Roman numerals from I through to VII and is now open ended to X (ten) and beyond. One key advantage of this system is its <a href="https://www.theuiaa.org/mountaineering/uiaa-grades-for-rock-climbing/" target="blank">clear descriptions</a> from grades I to VII. Essentially the system grades the hardest move in the route. However, the system takes no real account of either protection available or other factors that may impact a climber’s performance like exposure or altitude. As such the Alpine system or Scale of Global Assessment and French <em>sport</em> systems are both offshoots/additions of the UIAA scale, which itself is developed from the Welzenbach Scale.<br /><strong>Example</strong>: The climb <a href="/climbs/esparraguera-on-roca-gris/">Esparraguera on Roca Gris</a> is graded V+. This speaks to the hardest move, which is pulling up on a jug on the 3rd pitch. However the climb is also graded f5c, which is a slightly high conversion. The reason being the French sport system looks at the difficulty of each pitch (or length of rope) not just the hardest move, but also not the whole route like the alpine system. The UIAA scale and sport grade say nothing about the complexity of the route in terms of exposure, loose rock, route finding and run-out sections. Being comfortable climbing a UIAA V+ or f5c for 30m would be poor training for this beautifully complex route. <br /> <a class="seperated-link " href="/climbs/esparraguera-on-roca-gris/">The climb Esparraguera on Grey Rock graded UIAA V+ &#8250;</a>
+            </p>
+        </article><article class="row">
+            <h2 class="col-12">Yosemite Decimal System</h2>
+            <div class="col-12 col-md-4 col-sm-5 col-lg-3">
+                <figure class="compend-fig" tabindex="0" onkeydown="return event.code != 'Enter' || openLightBox('/img/other/grades/joy-climb-in-canada.jpg', 'Joy, A classic climb in Canada')"
+                    onclick="openLightBox('/img/other/grades/joy-climb-in-canada.jpg', 'Joy, A classic climb in Canada')">
+                    <picture>    
+                        <source srcset="/img/other/grades/joy-climb-in-canada-s.webp" type="image/webp" >
+                        <source srcset="/img/other/grades/joy-climb-in-canada-s.jpg" type="image/jpg" >
+                        <img src="/img/other/grades/joy-climb-in-canada-s.jpg" alt="Joy, A classic climb in Canada" class="cat-img" loading="lazy"/>
+                    </picture>
+                    <figcaption>Joy, A classic climb in Canada</figcaption>
+                </figure>
+            </div>
+            <p class="col-12 col-md-8 col-sm-7 col-lg-9">
+                The Yosemite Decimal System has a lot of complexity to it, most of which isn’t used day to day. Firstly, the initial number before the decimal indicates the type of terrain where 4 is roped scrambling and 5 is climbing. 1 would presumably be walking to the shop. Aid climbs originally started with a 6 but most people don’t use that anymore. All multi-pitch free climbing will start with a five. 5.4 is easer than 5.9. Once the scale hits 5.10 then letters a, b, c and d can be added. Ie 5.10a. The system grades the hardest move, although on modern routes the grades factor in how sustained they are as well. <br /> <strong>Example</strong>: The climb <a href="/climbs/joy-on-mount-indefatigable/">Joy on Mount Indefatigable</a> is graded around 5.7. The grade band between 5.5 and 5.9 is pretty tight, in addition, because the Yosemite Decimal system looks at the hardest move, you can easily add 2 grades to the climb by taking a tiny variation on one pitch. The route joy is between 5.6 and 5.8 on the YDS scale. <br /> <a class="seperated-link " href="/climbs/joy-on-mount-indefatigable/">The climb Joy gradded between 5.7 & 5.9 on the Yosemite Decimal System &#8250;</a>
+            </p>
+        </article><article class="row">
+            <h2 class="col-12">French Sport Grades</h2>
+            <div class="col-12 col-md-4 col-sm-5 col-lg-3">
+                <figure class="compend-fig" tabindex="0" onkeydown="return event.code != 'Enter' || openLightBox('/img/other/grades/bruggler-offers-great-climbing-in-switzerland.jpg', 'Brüggler in Switzerland uses French grades.')"
+                    onclick="openLightBox('/img/other/grades/bruggler-offers-great-climbing-in-switzerland.jpg', 'Brüggler in Switzerland uses French grades.')">
+                    <picture>    
+                        <source srcset="/img/other/grades/bruggler-offers-great-climbing-in-switzerland-s.webp" type="image/webp" >
+                        <source srcset="/img/other/grades/bruggler-offers-great-climbing-in-switzerland-s.jpg" type="image/jpg" >
+                        <img src="/img/other/grades/bruggler-offers-great-climbing-in-switzerland-s.jpg" alt="Brüggler in Switzerland uses French grades." class="cat-img" loading="lazy"/>
+                    </picture>
+                    <figcaption>Brüggler in Switzerland uses French grades.</figcaption>
+                </figure>
+            </div>
+            <p class="col-12 col-md-8 col-sm-7 col-lg-9">
+                French numerical grades were originally an offshoot of the UIAA system. In theorythey aim to grade the difficulty of a pitch. However whole routes are given the grade of the hardest pitch. The scale currently runs from 1 to 9c. Grades from 3 onwards can be sub divided into a, b & c for example 5c is harder than 5b. Grades from 6a onwards can additionally have a plus (and occasionally a minus) added where a 6a+ is harder than a 6a but easier than a 6b. This is the most common system used for grading sport routes and is used in most lead climbing gyms in Europe. The major downside to the system is that it doesn’t take into account protection or rock quality, or even the overall difficulty of multi-pitch rock climbs.<br /><strong>Example</strong>: <a href="/climbs/visite-obligatoire-on-aiguille-dibona/">Visite Obligatoire on the mountain Aiguille Dibona</a> is graded 6a+. It has some tough pitches,but being able to climb 6a+ in the gym is not going to be enough to get you up all 350m of this route. In fact climbers who can often manage 6c or 7a have failed to ascend this route. Therefore the alpine adjectival grade of <em>trés difficile</em> is much more representitive. I.e. it’s a solid E1 in British grades. The route Direkte Plattenwand on Brüggler in Switzerland is largely bolted and so a sport grade here is more useful. <br /> <a class="seperated-link " href="/climbs/direkte-plattenwand-on-brüggler/">Climbing the center of Brüggler is graded 5a  &#8250;</a>
+            </p>
+        </article><article class="row">
+            <h2 class="col-12">Norwegian Grades</h2>
+            <div class="col-12 col-md-4 col-sm-5 col-lg-3">
+                <figure class="compend-fig" tabindex="0" onkeydown="return event.code != 'Enter' || openLightBox('/img/other/grades/stetind-climb-in-norway.jpg', 'Stetind is Norways national mountain')"
+                    onclick="openLightBox('/img/other/grades/stetind-climb-in-norway.jpg', 'Stetind is Norways national mountain')">
+                    <picture>    
+                        <source srcset="/img/other/grades/stetind-climb-in-norway-s.webp" type="image/webp" >
+                        <source srcset="/img/other/grades/stetind-climb-in-norway-s.jpg" type="image/jpg" >
+                        <img src="/img/other/grades/stetind-climb-in-norway-s.jpg" alt="Stetind is Norways national mountain" class="cat-img" loading="lazy"/>
+                    </picture>
+                    <figcaption>Stetind is Norways national mountain</figcaption>
+                </figure>
+            </div>
+            <p class="col-12 col-md-8 col-sm-7 col-lg-9">
+                The Norwegian Grading system started out as the UIAA system but as climbing progressed up to and then past the original ceiling of the sixth grade, the Norwegian system diverged. It switched to using Arabic numbers ie. 6 rather than Roman Numerals ie VI. The main difference is, grades tend to be slightly harder at around the fifth grade and beyond.<br /><strong>Example</strong>: The <a href="/climbs/sydpillaren-on-stetind/">South Pillar climb on Stetind </a> is graded around 6-. This makes the route somewhere between HVS and E1. Given the length and seriousness of the route E1 is possibly the more appropriate conversion to British grades, but it is a full VI on the UIAA scale. <br /> <a class="seperated-link " href="/climbs/sydpillaren-on-stetind/">Graded 6- on the Norwegian scale, The South pillar climb on Stetind is breathtaking &#8250;</a>
+            </p>
+        </article><article class="row">
+            <h2 class="col-12">Alpine Scale</h2>
+            <div class="col-12 col-md-4 col-sm-5 col-lg-3">
+                <figure class="compend-fig" tabindex="0" onkeydown="return event.code != 'Enter' || openLightBox('/img/other/grades/aiguille-debona.jpg', 'Aiguille Dibona, named after the Italian Mountaineer')"
+                    onclick="openLightBox('/img/other/grades/aiguille-debona.jpg', 'Aiguille Dibona, named after the Italian Mountaineer')">
+                    <picture>    
+                        <source srcset="/img/other/grades/aiguille-debona-s.webp" type="image/webp" >
+                        <source srcset="/img/other/grades/aiguille-debona-s.jpg" type="image/jpg" >
+                        <img src="/img/other/grades/aiguille-debona-s.jpg" alt="Aiguille Dibona, named after the Italian Mountaineer" class="cat-img" loading="lazy"/>
+                    </picture>
+                    <figcaption>Aiguille Dibona, named after the Italian Mountaineer</figcaption>
+                </figure>
+            </div>
+            <p class="col-12 col-md-8 col-sm-7 col-lg-9">
+                The Scale of Global Assessment, usually called the Alpine Scale, gives an overall adjectival grade to climbing routes much like the British system. This fills the gap in the UIAA and sport grading systems where the grade says little about the seriousness of the route. The system uses French terms and runs from F for facile (easy in English) to ED for extrêmement difficile (extremely difficult) ED is open ended with numbers to ED4.<br /><strong>Example</strong>: <a href="/climbs/visite-obligatoire-on-aiguille-dibona/">Visite Obligatoire on the mountain Aiguille Dibona</a> is graded TD. TD is described as Very hard. Routes at this grades are serious undertakings with high level of objective danger... Rock climbing at UIAA grade V and VI with possible aid, very long sections of hard climbing. The alpine adjectival grade of <em>trés difficile</em> is a solid E1 in British grades. <br /> <a class="seperated-link " href="/climbs/visite-obligatoire-on-aiguille-dibona/">The Obligatory Visit on Aiguille Dibona is graded trés difficile &#8250;</a>
+            </p>
+        </article>
+    </section>
+    </div>
+</main><!--Footer-->
+<footer class="page-footer text-center">
+    <section class="footer-image">
+        <div class="footer-image-filter">
+            <div class="container">
+                <div class="row">
+                    <div class="col-12 col-md-4">
+                        <h4><label for="mce-EMAIL">Subscribe to Email Updates</label></h4>
+                    </div>
+                    <div class="col-12 col-md-8">
+                        <form action="https://multi-pitch.us19.list-manage.com/subscribe/post?u=e6bb5a84231b4cc61f769f196&amp;id=1fadd83d1d"
+                         method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" target="blank">
+                            <input type="email" value="" name="EMAIL" id="mce-EMAIL" placeholder="email@domain.com" class="subscribe-input email" />
+                            <input  type="submit" aria-label="subscribe" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="subscribe-button" />
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>    
+    <section class="grey">
+        <div class="container">
+            <div class="row">
+                <div class="col-12">
+                    <video autoplay loop muted playsinline class="danger-gif" >
+                        <source src="/img/other/danger/climb-danger.webm" type="video/webm"> 
+                        <source src="/img/other/danger/climb-danger.mp4" type="video/mp4">  
+                    </video>
+                    <h4>Rock Climbing is Dangerous</h4>
+                    <p style="min-height:90px">
+                        <strong>Do not use any information in this website to plan, attempt, or climb a particular route 
+                        unless you are willing to assume personal responsibility for all risks associated. Don't 
+                        treat this site as instruction.</strong> Rock climbing is an activitiy with a
+                        danger of personal injury or death. Participants should be aware of and accept these risks and be
+                        responsible for their own actions. If in doubt, don't climb.
+                        <a href="https://www.thebmc.co.uk/risk-and-safety" target="blank">
+                            <abbr title="British Mountaineering Council">BMC</abbr> Statement <i class=" icon-link-ext" aria-hidden="true"></i>
+                        </a>
+                    </p>
+                </div>
+            
+            </div>
+        </div>
+    </section>
+    <section class="footer-copyright">
+
+        <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="blank">&copy; 2026 Creative Commons</a> - 
+        <a href="/">multi-pitch.com </a> - 
+        <a href="/about/#contact">Contact</a>        
+        <button type="button" class="theme-toggle footer-theme-toggle" aria-pressed="false" aria-label="Switch to dark theme">
+            <svg class="tt-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            <svg class="tt-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><path d="M12 1v3M12 20v3M4.22 4.22l2.12 2.12M17.66 17.66l2.12 2.12M1 12h3M20 12h3M4.22 19.78l2.12-2.12M17.66 6.34l2.12-2.12"/></svg>
+        </button>
+    </section>
+
+</footer>
+<div class="overlay" id="overlay"></div>
+<script>
+    window.performance.mark('html-end');
+</script>
+ </body>

--- a/website/climbing-grades/index.html
+++ b/website/climbing-grades/index.html
@@ -312,7 +312,7 @@
                     <picture>    
                         <source srcset="/img/other/grades/weakers-slab-in-north-cornwall-s.webp" type="image/webp" >
                         <source srcset="/img/other/grades/weakers-slab-in-north-cornwall-s.jpg" type="image/jpg" >
-                        <img src="/img/other/grades/weakers-slab-in-north-cornwall-s.jpg" alt="VS climbing in North Cornwall" class="cat-img" loading="lazy"/>
+                        <img src="/img/other/grades/weakers-slab-in-north-cornwall-s.jpg" alt="VS climbing in North Cornwall" class="cat-img" width="600" height="600" loading="lazy"/>
                     </picture>
                     <figcaption>VS climbing in North Cornwall</figcaption>
                 </figure>
@@ -328,7 +328,7 @@
                     <picture>    
                         <source srcset="/img/other/grades/roca-gris-in-montserrat-spain-s.webp" type="image/webp" >
                         <source srcset="/img/other/grades/roca-gris-in-montserrat-spain-s.jpg" type="image/jpg" >
-                        <img src="/img/other/grades/roca-gris-in-montserrat-spain-s.jpg" alt="Grade V+ climb in Montserrat Spain" class="cat-img" loading="lazy"/>
+                        <img src="/img/other/grades/roca-gris-in-montserrat-spain-s.jpg" alt="Grade V+ climb in Montserrat Spain" class="cat-img" width="600" height="600" loading="lazy"/>
                     </picture>
                     <figcaption>Grade V+ climb in Montserrat Spain</figcaption>
                 </figure>
@@ -344,7 +344,7 @@
                     <picture>    
                         <source srcset="/img/other/grades/joy-climb-in-canada-s.webp" type="image/webp" >
                         <source srcset="/img/other/grades/joy-climb-in-canada-s.jpg" type="image/jpg" >
-                        <img src="/img/other/grades/joy-climb-in-canada-s.jpg" alt="Joy, A classic climb in Canada" class="cat-img" loading="lazy"/>
+                        <img src="/img/other/grades/joy-climb-in-canada-s.jpg" alt="Joy, A classic climb in Canada" class="cat-img" width="600" height="600" loading="lazy"/>
                     </picture>
                     <figcaption>Joy, A classic climb in Canada</figcaption>
                 </figure>
@@ -360,7 +360,7 @@
                     <picture>    
                         <source srcset="/img/other/grades/bruggler-offers-great-climbing-in-switzerland-s.webp" type="image/webp" >
                         <source srcset="/img/other/grades/bruggler-offers-great-climbing-in-switzerland-s.jpg" type="image/jpg" >
-                        <img src="/img/other/grades/bruggler-offers-great-climbing-in-switzerland-s.jpg" alt="Brüggler in Switzerland uses French grades." class="cat-img" loading="lazy"/>
+                        <img src="/img/other/grades/bruggler-offers-great-climbing-in-switzerland-s.jpg" alt="Brüggler in Switzerland uses French grades." class="cat-img" width="600" height="600" loading="lazy"/>
                     </picture>
                     <figcaption>Brüggler in Switzerland uses French grades.</figcaption>
                 </figure>
@@ -376,7 +376,7 @@
                     <picture>    
                         <source srcset="/img/other/grades/stetind-climb-in-norway-s.webp" type="image/webp" >
                         <source srcset="/img/other/grades/stetind-climb-in-norway-s.jpg" type="image/jpg" >
-                        <img src="/img/other/grades/stetind-climb-in-norway-s.jpg" alt="Stetind is Norways national mountain" class="cat-img" loading="lazy"/>
+                        <img src="/img/other/grades/stetind-climb-in-norway-s.jpg" alt="Stetind is Norways national mountain" class="cat-img" width="600" height="600" loading="lazy"/>
                     </picture>
                     <figcaption>Stetind is Norways national mountain</figcaption>
                 </figure>
@@ -392,7 +392,7 @@
                     <picture>    
                         <source srcset="/img/other/grades/aiguille-debona-s.webp" type="image/webp" >
                         <source srcset="/img/other/grades/aiguille-debona-s.jpg" type="image/jpg" >
-                        <img src="/img/other/grades/aiguille-debona-s.jpg" alt="Aiguille Dibona, named after the Italian Mountaineer" class="cat-img" loading="lazy"/>
+                        <img src="/img/other/grades/aiguille-debona-s.jpg" alt="Aiguille Dibona, named after the Italian Mountaineer" class="cat-img" width="600" height="600" loading="lazy"/>
                     </picture>
                     <figcaption>Aiguille Dibona, named after the Italian Mountaineer</figcaption>
                 </figure>

--- a/website/components/article.js
+++ b/website/components/article.js
@@ -123,22 +123,14 @@ function generateArticlesHTML(content, sorted){
   
 function updateBreadcrumb(url){
     let parts = url.split('/');
-    let breadcrumbDisplay = 'none';
-    let breadcrumbUrl = '';
     let breadcrumbTxt = '';
-    // Its a 3rd lvl page
-    if(parts[2]){
-        breadcrumbDisplay = 'inline';
-        breadcrumbUrl = url;
-        parts[2] = parts[2].charAt(0).toUpperCase() + parts[2].slice(1);
-        breadcrumbTxt = parts[2].replace('-', ' ');
+    if(parts[1]){
+        breadcrumbTxt = parts[1].charAt(0).toUpperCase() + parts[1].slice(1).replace(/-/g, ' ');
     }
     let html = `
     <div id="breadcrumb">
         <a href="/">Home</a> /
-        <a href="/climbing-tips/" class="pushable">Compendium</a> 
-        <span id="dividerTwo" style="display: ${breadcrumbDisplay};">/</span>
-        <a href="${breadcrumbUrl}" class="pushable" id="thirdLvl" style="display: ${breadcrumbDisplay};">${breadcrumbTxt}</a>
+        <a href="${url}" class="pushable" id="thirdLvl">${breadcrumbTxt}</a>
     </div>`;
     return html;
 }

--- a/website/components/article.js
+++ b/website/components/article.js
@@ -106,7 +106,7 @@ function generateArticlesHTML(content, sorted){
                     <picture>    
                         <source srcset="${webPUrl}" type="image/webp" >
                         <source srcset="${url}" type="image/jpg" >
-                        <img src="${url}" alt="${alt}" class="cat-img" loading="lazy"/>
+                        <img src="${url}" alt="${alt}" class="cat-img" width="600" height="600" loading="lazy"/>
                     </picture>
                     <figcaption>${alt}</figcaption>
                 </figure>

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -1647,6 +1647,7 @@ html[data-theme="dark"] .warning{
 }
 .cat-img{
   width:100%;
+  height:auto;
   max-width: 300px;
   margin:0 10px 10px 0;
   background-color: #CCCCCC;

--- a/website/index.html
+++ b/website/index.html
@@ -165,9 +165,9 @@
                         </p>
                         <p>
                             All climbs are graded using their original grading system. You can
-                            <a href="/climbing-tips/climbing-grades/" rel="no-follow" id="climbingGradeModal"
-                                onClick="openModal('/climbing-tips/climbing-grades/content.html', this.id);return false;"
-                                onKeyDown="return event.code != 'Enter' || openModal('/climbing-tips/climbing-grades/content.html',  this.id);"> 
+                            <a href="/climbing-grades/" rel="no-follow" id="climbingGradeModal"
+                                onClick="openModal('/climbing-grades/content.html', this.id);return false;"
+                                onKeyDown="return event.code != 'Enter' || openModal('/climbing-grades/content.html',  this.id);"> 
                                 convert climbing grades
                             </a>
                             to a different system. This is however, by its nature, <em>wildly</em> subjective. 
@@ -180,8 +180,8 @@
                                     <h5>
                                         Grade 
                                         <small>
-                                            (<abbr id="gradeSys" title="British Adjectival System" onClick="openModal('/climbing-tips/climbing-grades/content.html', this.id)">British Adjectival System</abbr>)
-                                            <a id="changeLink" href="/climbing-tips/climbing-grades/" onClick="openModal('/climbing-tips/climbing-grades/content.html', this.id); return false">change</a>
+                                            (<abbr id="gradeSys" title="British Adjectival System" onClick="openModal('/climbing-grades/content.html', this.id)">British Adjectival System</abbr>)
+                                            <a id="changeLink" href="/climbing-grades/" onClick="openModal('/climbing-grades/content.html', this.id); return false">change</a>
                                         </small>  
                                     </h5>
                                     <div class="controls">


### PR DESCRIPTION
## Context

Confirmed with Dan: removing the `climbing-tips` section (commit [`a438645`](https://github.com/dankni/multi-pitch/commit/a43864513c8e58d34f48540d9dfcb51ea017809a)) was intentional, but `climbing-grades` was meant to survive it. That commit deleted `climbing-tips/climbing-grades/content.html` without accounting for the fact it was double-booked: it served both as an indexable info page *and* as the fetch target for the homepage's grade-conversion modal. Since nothing else replaced it, clicking "change" next to any climb grade silently did nothing on prod — the feature (`gradeSys`/`changeLink` → `updateGradePref`/`updateListingGrades` in `main.js`) was fully wired but had no content to show.

This PR keeps the tips section gone, restores just climbing-grades at a decoupled top-level URL, and cleans up the other loose ends from that removal.

## Changes

- **Moved `climbing-grades` out from under `climbing-tips`** to its own `/climbing-grades/` URL. This also matches a pre-existing (but backwards) S3 redirect rule that implied `/climbing-grades/` was the page's original home before an earlier reorg.
- **Restored a trimmed `generateContentPages.js`** that builds only this one page (not the other 4 tips pages), and wired `generate-content` back into `npm run generate-all`.
- **Simplified `article.js`'s `updateBreadcrumb`**: it hardcoded a middle "Compendium" crumb linking to `/climbing-tips/`, which no longer exists. Since there's no hub page anymore, breadcrumbs now go straight `Home → page`.
- **Added climbing-grades back into the sitemap**, reusing the `tipsLastmod` helper `generateSiteMap.js` still had sitting around unused after the tips entries were stripped.
- **Fixed S3 redirect rules**: flipped the stale `climbing-grades/ → climbing-tips/climbing-grades/` rule (which — since it has no error-code condition — would have unconditionally bounced the restored page away before it could ever serve), and added 301s for the four tips pages that really are gone for good (`climbing-tips/`, `climbing-gear/`, `rock-types/`, `climbing-terminology/`) → `/blog/`, so Search Console doesn't relight with fresh 404 coverage errors on the next crawl.

## Testing

- Ran `generate-content` and `generate-sitemap` locally — clean output, correct canonical URL, one JSON-LD block, no leftover `{{placeholders}}`.
- `xmllint` validated the updated `s3-rules.xml`.
- All 11 Cypress e2e tests pass.
- Screenshotted locally: the standalone `/climbing-grades/` page renders correctly (nav, breadcrumb, table, articles, footer); the homepage grade-conversion modal opens, lets you pick a system (tested YDS), and correctly converts the listed climb grades and updates the "(YDS) change" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)