### PR TITLE
Forecast title: 16 -> 14 days

### DIFF
--- a/website/components/climbCard.js
+++ b/website/components/climbCard.js
@@ -214,7 +214,7 @@ function getWeather(climb) {
             <abbr title="Ultraviolet">UV</abbr> Index is <strong id="uv_index"></strong> which is considered <span id="uv_description"></span>
           </p>
           <p class="chart-title">
-            Recent rain & 16 day forecast
+            Recent rain & 14 day forecast
           </p>
           <div class="wx-strip-wrap">
             <button type="button" class="wx-scroll wx-scroll-left" aria-label="Earlier days"


### PR DESCRIPTION
The window was resized to 3 past + 14 forecast days; the section title still said 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)