### PR TITLE
GA4 direct config + working event tracking

### DIFF
--- a/website/404/index.html
+++ b/website/404/index.html
@@ -14,12 +14,12 @@
     <link href="/css/style.css" rel="stylesheet" />
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-123782847-1"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XR0EG1VTTE"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'UA-123782847-1');
+      gtag('config', 'G-XR0EG1VTTE');
     </script>
 
     <!-- Favicons -->

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -154,7 +154,9 @@ GA TRACKING HELPER
 **/
 window.trackGA = function(category, action, label, value = 0) {
     try{
-        ga('gtag_UA_123782847_1' + '.send', 'event', category, action, label, value);
+        // gtag (GA4) - the old ga()/analytics.js API was never loaded, so
+        // event tracking had been silently dead for years
+        gtag('event', action, { event_category: category, event_label: label, value: value });
     }
     catch (e) {
         // console.log("failed to track event" + e);
@@ -1228,12 +1230,13 @@ function loadNonEssential(type, url, mod = false){
  **/
 function LoadAnalytics(){
     window.performance.mark('gta-start');
-    loadNonEssential("script", "https://www.googletagmanager.com/gtag/js?id=UA-123782847-1");
+    loadNonEssential("script", "https://www.googletagmanager.com/gtag/js?id=G-XR0EG1VTTE");
     setTimeout(function(){
         window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
+        window.gtag = function() { dataLayer.push(arguments); }
         gtag('js', new Date());
-        gtag('config', 'UA-123782847-1');
+        // GA4 directly - no longer relying on Google's UA connected-tag redirect
+        gtag('config', 'G-XR0EG1VTTE');
         window.performance.mark('gta-end');
     }, 1000);
 

--- a/website/training/common/functions.js
+++ b/website/training/common/functions.js
@@ -87,12 +87,12 @@ function loadNonEssential(type, url){
 }
 function loadAnalytics(){
     window.performance.mark('gta-start');
-    loadNonEssential("script", "https://www.googletagmanager.com/gtag/js?id=UA-123782847-1");
+    loadNonEssential("script", "https://www.googletagmanager.com/gtag/js?id=G-XR0EG1VTTE");
     setTimeout(function(){
         window.dataLayer = window.dataLayer || [];
         function gtag() { dataLayer.push(arguments); }
         gtag('js', new Date());
-        gtag('config', 'UA-123782847-1');
+        gtag('config', 'G-XR0EG1VTTE');
         window.performance.mark('gta-end');
     }, 1000);
 


### PR DESCRIPTION
Pageviews already reached GA4 (`G-XR0EG1VTTE`) via Google's connected-site-tag redirect on the UA id — but custom events never arrived: `trackGA()` used the legacy `ga()` API that this site never loads, so every sort/filter/interaction event has been silently dropped since the gtag migration.

- `gtag('config', 'G-XR0EG1VTTE')` everywhere (main.js, training pages, 404) — no more reliance on the UA redirect Google could retire
- `trackGA` now sends real `gtag('event', ...)` calls — event data flows for the first time

🤖 Generated with [Claude Code](https://claude.com/claude-code)