### PR TITLE
Proposal: weather note wording (for @dankni's review)

### DIFF
--- a/website/components/climbCard.js
+++ b/website/components/climbCard.js
@@ -194,10 +194,8 @@ function getWeather(climb) {
           ${seepage}
           <aside style="margin-bottom:2.5rem;">
             <small>
-            Please Note: <em>This forecast is a weather model run for the climb's coordinates and elevation.
-            A multi-pitch route climbs through its own weather &mdash; the top-out can be several degrees colder
-            and windier than the base &mdash; and models are least accurate in remote mountains.
-            Don't take the forecast for granted.</em>
+            Please Note: <em>This forecast comes from a weather model calculated for the climb's coordinates.
+            Never take a forecast for granted.</em>
             </small>
           </aside>
         </div>

--- a/website/components/climbCard.js
+++ b/website/components/climbCard.js
@@ -194,9 +194,10 @@ function getWeather(climb) {
           ${seepage}
           <aside style="margin-bottom:2.5rem;">
             <small>
-            Please Note: <em>This forecast comes from a weather model calculated for the climb's coordinates and elevation
-            &mdash; there is no weather station on the crag. Mountain routes often read colder and windier than the
-            village forecast, but a model can still miss local conditions. Don't take the forecast for granted.</em>
+            Please Note: <em>This forecast is a weather model run for the climb's coordinates and elevation.
+            A multi-pitch route climbs through its own weather &mdash; the top-out can be several degrees colder
+            and windier than the base &mdash; and models are least accurate in remote mountains.
+            Don't take the forecast for granted.</em>
             </small>
           </aside>
         </div>

--- a/website/components/climbCard.js
+++ b/website/components/climbCard.js
@@ -194,8 +194,9 @@ function getWeather(climb) {
           ${seepage}
           <aside style="margin-bottom:2.5rem;">
             <small>
-            Please Note: <em>This forecast is calculated for the climb's coordinates. Not all routes have weather stations nearby. 
-            For more remote mountain routes it may be noticeably different. Don't take the forecast for granted.</em>
+            Please Note: <em>This forecast comes from a weather model calculated for the climb's coordinates and elevation
+            &mdash; there is no weather station on the crag. Mountain routes often read colder and windier than the
+            village forecast, but a model can still miss local conditions. Don't take the forecast for granted.</em>
             </small>
           </aside>
         </div>


### PR DESCRIPTION
@dankni — following your comment on 52aa3a8 (fair hit: the previous wording oversold model output as ground truth). Your fix restored the right humility, but one detail swung back: *"Not all routes have weather stations nearby"* — station proximity doesn't apply to this forecast either way. Open-Meteo is a numerical weather model downscaled to the coordinates' elevation, not station interpolation; there's no station involved even in the Dolomites.

Proposed middle ground (keeps your warning, drops the station framing, keeps the one verified fact that explains why our numbers differ from a village forecast):

> This forecast comes from a weather model calculated for the climb's coordinates and elevation — there is no weather station on the crag. Mountain routes often read colder and windier than the village forecast, but a model can still miss local conditions. Don't take the forecast for granted.

For reference, the elevation adjustment is real and checkable: the Sass Pordoi feed forecasts at 2709m and reads ~9°C colder than BBC's Canazei (valley, ~1450m) — almost exactly the standard lapse rate.

Entirely your call — happy to close this if you prefer your wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)